### PR TITLE
More extensive validation handling

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -14,11 +14,13 @@
 % Event Information. A serialized version of this record
 % is sent by the browser when an event is called.
 -record(event_context, {
-  module,     % The module that should handle the event
-  tag,        % An Erlang term that is passed along with the event
-  type,       % The type of event postback, comet, continuation, upload
+	module,     % The module that should handle the event
+	tag,        % An Erlang term that is passed along with the event
+	type,       % The type of event postback, comet, continuation, upload
 	anchor,     % The element id to which trigger and target are relative.
-	validation_group % The validation group that should be run when this event is fired.
+	validation_group, % The validation group that should be run when this event is fired.
+	handle_invalid % When an invalidation evaluates to false, instead of silently not
+	               % issuing a postback event, call Delegate:event_invalid with the same tag.
 }).
 
 % Handlers Context-
@@ -80,21 +82,21 @@
 -record(p, {?ELEMENT_BASE(element_p), body=""}).
 -record(label, {?ELEMENT_BASE(element_label), text="", html_encode=true}).
 -record(value, {?ELEMENT_BASE(element_value), text="", html_encode=true}).
--record(link, {?ELEMENT_BASE(element_link), title = "", text="", body="", html_encode=true, url="javascript:", postback, delegate}).
+-record(link, {?ELEMENT_BASE(element_link), title = "", text="", body="", html_encode=true, url="javascript:", postback, handle_invalid=false, on_invalid, delegate}).
 -record(error, {?ELEMENT_BASE(element_error), text="", html_encode=true}).
 -record(span, {?ELEMENT_BASE(element_span), text="", html_encode=true}).
--record(button, {?ELEMENT_BASE(element_button), text="Button", html_encode=true, postback, delegate}).
+-record(button, {?ELEMENT_BASE(element_button), text="Button", html_encode=true, postback, handle_invalid=false, on_invalid, delegate}).
 -record(literal, {?ELEMENT_BASE(element_literal), text="", html_encode=true}).
--record(textbox, {?ELEMENT_BASE(element_textbox), text="", html_encode=true, next, postback, delegate}).
+-record(textbox, {?ELEMENT_BASE(element_textbox), text="", html_encode=true, next, postback, handle_invalid=false, on_invalid, delegate}).
 -record(hidden, {?ELEMENT_BASE(element_hidden), text="", html_encode=true}).
 -record(textarea, {?ELEMENT_BASE(element_textarea), text="", html_encode=true}).
 -record(datepicker_textbox, {?ELEMENT_BASE(element_datepicker_textbox), text="", next, html_encode=true, validators=[], options = [{dateFormat, "yy-mm-dd"}] }).
--record(dropdown, {?ELEMENT_BASE(element_dropdown), options=[], html_encode=true, postback, delegate, value}).
+-record(dropdown, {?ELEMENT_BASE(element_dropdown), options=[], html_encode=true, postback, handle_invalid=false, on_invalid, delegate, value}).
 -record(option, { text="", value="", selected=false }).
--record(checkbox, {?ELEMENT_BASE(element_checkbox), text="", html_encode=true, checked=false, value="on", postback, delegate}).
+-record(checkbox, {?ELEMENT_BASE(element_checkbox), text="", html_encode=true, checked=false, value="on", postback, handle_invalid=false, on_invalid, delegate}).
 -record(radiogroup, {?ELEMENT_BASE(element_radiogroup), body=[]}).
--record(radio, {?ELEMENT_BASE(element_radio), text="", html_encode=true, value, name, checked=false, postback, delegate}).
--record(password, {?ELEMENT_BASE(element_password), text="", html_encode=true, next, postback, delegate}).
+-record(radio, {?ELEMENT_BASE(element_radio), text="", html_encode=true, value, name, checked=false, postback, handle_invalid=false, on_invalid, delegate}).
+-record(password, {?ELEMENT_BASE(element_password), text="", html_encode=true, next, postback, handle_invalid=false, on_invalid, delegate}).
 -record(panel, {?ELEMENT_BASE(element_panel), body=""}).
 -record(spinner, {?ELEMENT_BASE(element_spinner), image="/nitrogen/spinner.gif"}).
 -record(image, {?ELEMENT_BASE(element_image), image="", alt}).
@@ -118,7 +120,7 @@
 -record(wizard, {?ELEMENT_BASE(element_wizard), tag, titles, steps }).
 -record(upload, {?ELEMENT_BASE(element_upload), delegate, tag, show_button=true, button_text="Upload" }).
 -record(sparkline, {?ELEMENT_BASE(element_sparkline), type, values, options }).
--record(textbox_autocomplete, {?ELEMENT_BASE(element_textbox_autocomplete), tag, text="", minLength=2, delay=300, html_encode=true, next, postback, delegate=undefined }).
+-record(textbox_autocomplete, {?ELEMENT_BASE(element_textbox_autocomplete), tag, text="", minLength=2, delay=300, html_encode=true, next, postback, handle_invalid=false, on_invalid, delegate=undefined }).
 
 %% HTML5 semantic elements
 -record(section, {?ELEMENT_BASE(element_section), body=""}).
@@ -166,7 +168,7 @@
 -record(function, {?ACTION_BASE(action_function), function }).
 -record(set, {?ACTION_BASE(action_set), value}).
 -record(redirect, {?ACTION_BASE(action_redirect), url}).
--record(event, {?ACTION_BASE(action_event), type=default, keycode=undefined, delay=0, postback, validation_group, delegate, extra_param}).
+-record(event, {?ACTION_BASE(action_event), type=default, keycode=undefined, delay=0, postback, validation_group, handle_invalid=false, on_invalid, delegate, extra_param}).
 -record(validate, {?ACTION_BASE(action_validate), on=submit, success_text=" ", group, validators, attach_to }).
 -record(validation_error, {?ACTION_BASE(action_validation_error), text="" }).
 -record(alert, {?ACTION_BASE(action_alert), text=""}).

--- a/src/actions/action_event.erl
+++ b/src/actions/action_event.erl
@@ -7,16 +7,17 @@
 -compile(export_all).
 
 render_action(#event { 
-    postback=Postback, actions=Actions, 
-    anchor=Anchor, trigger=Trigger, target=Target, validation_group=ValidationGroup,
+    postback=Postback, actions=Actions,
+    anchor=Anchor, trigger=Trigger, target=Target,
+    validation_group=ValidationGroup, handle_invalid=HandleInvalid, on_invalid=OnInvalid,
     type=Type, keycode=KeyCode, delay=Delay, delegate=Delegate, 
     extra_param=ExtraParam
 }) -> 
 
     ValidationGroup1 = wf:coalesce([ValidationGroup, Trigger]),
     AnchorScript = wf_render_actions:generate_anchor_script(Anchor, Target), 
-    PostbackScript = wf_event:generate_postback_script(Postback, Anchor, ValidationGroup1, Delegate, ExtraParam),
-    SystemPostbackScript = wf_event:generate_system_postback_script(Postback, Anchor, ValidationGroup1, Delegate),
+    PostbackScript = wf_event:generate_postback_script(Postback, Anchor, ValidationGroup1, HandleInvalid, OnInvalid, Delegate, ExtraParam),
+    SystemPostbackScript = wf_event:generate_system_postback_script(Postback, Anchor, ValidationGroup1, HandleInvalid, Delegate),
     WireAction = #wire { trigger=Trigger, target=Target, actions=Actions },
 
     Script = case Type of

--- a/src/actions/action_validate.erl
+++ b/src/actions/action_validate.erl
@@ -27,6 +27,7 @@ render_action(Record) ->
     % TODO: using jQuery.data instead setting the validator object as property 
     % of the DOM node. We could get a problem with Internet Explorer and memory leaks.
     ConstructorJS = wf:f("var v = obj('~s').validator = new LiveValidation(obj('~s'), { validMessage: \"~s\", onlyOnBlur: ~s, onlyOnSubmit: ~s ~s});", [TargetPath, TargetPath, wf:js_escape(ValidMessage), OnlyOnBlur, OnlyOnSubmit, InsertAfterNode]),
+
     TriggerJS = wf:f("v.group = '~s';", [ValidationGroup]),
 
     % Update all child validators with TriggerPath and TargetPath...

--- a/src/elements/forms/element_button.erl
+++ b/src/elements/forms/element_button.erl
@@ -13,7 +13,13 @@ render_element(Record) ->
     Anchor = Record#button.anchor,
     case Record#button.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=click, validation_group=ID, postback=Postback, delegate=Record#button.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=click,
+                    validation_group=ID,
+                    postback=Postback,
+                    handle_invalid=Record#button.handle_invalid,
+                    on_invalid=Record#button.on_invalid,
+                    delegate=Record#button.delegate })
     end,
 
     Value = ["  ", wf:html_encode(Record#button.text, Record#button.html_encode), "  "], 

--- a/src/elements/forms/element_checkbox.erl
+++ b/src/elements/forms/element_checkbox.erl
@@ -17,7 +17,13 @@ render_element(Record) ->
     end,
     case Record#checkbox.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=change, postback=Postback, validation_group=ID, delegate=Record#checkbox.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=change,
+                    postback=Postback,
+                    validation_group=ID,
+                    handle_invalid=Record#checkbox.handle_invalid,
+                    on_invalid=Record#checkbox.on_invalid,
+                    delegate=Record#checkbox.delegate })
     end,
 
     Text = wf:html_encode(Record#checkbox.text, Record#checkbox.html_encode),

--- a/src/elements/forms/element_password.erl
+++ b/src/elements/forms/element_password.erl
@@ -17,7 +17,13 @@ render_element(Record) ->
     end,
     case Record#password.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=enterkey, postback=Postback, validation_group=ID, delegate=Record#password.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=enterkey,
+                    postback=Postback,
+                    validation_group=ID,
+                    handle_invalid=Record#password.handle_invalid,
+                    on_invalid=Record#password.on_invalid,
+                    delegate=Record#password.delegate })
     end,
 
     Value = wf:html_encode(Record#password.text, Record#password.html_encode),

--- a/src/elements/forms/element_radio.erl
+++ b/src/elements/forms/element_radio.erl
@@ -18,7 +18,13 @@ render_element(Record) ->
 
     case Record#radio.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=change, postback=Postback, validation_group=ID, delegate=Record#radio.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=change,
+                    postback=Postback,
+                    validation_group=ID,
+                    handle_invalid=Record#radio.handle_invalid,
+                    on_invalid=Record#radio.on_invalid,
+                    delegate=Record#radio.delegate })
     end,
 
     Content = wf:html_encode(Record#radio.text, Record#radio.html_encode),

--- a/src/elements/forms/element_textbox.erl
+++ b/src/elements/forms/element_textbox.erl
@@ -20,7 +20,13 @@ render_element(Record) ->
 
     case Record#textbox.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=enterkey, postback=Postback, validation_group=ID, delegate=Record#textbox.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=enterkey,
+                    postback=Postback,
+                    validation_group=ID,
+                    handle_invalid=Record#textbox.handle_invalid,
+                    on_invalid=Record#textbox.on_invalid,
+                    delegate=Record#textbox.delegate })
     end,
 
     Value = wf:html_encode(Record#textbox.text, Record#textbox.html_encode),

--- a/src/elements/forms/element_upload.erl
+++ b/src/elements/forms/element_upload.erl
@@ -44,7 +44,7 @@ render_element(Record) ->
     IFrameID = wf:temp_id(),
     ButtonID = wf:temp_id(),
     SubmitJS = wf:f("Nitrogen.$upload(jQuery('#~s').get(0));", [FormID]),
-    PostbackInfo = wf_event:serialize_event_context(FinishedTag, Record#upload.id, undefined, ?MODULE),
+    PostbackInfo = wf_event:serialize_event_context(FinishedTag, Record#upload.id, undefined, false, ?MODULE),
 
     % Create a postback that is called when the user first starts the upload...
     wf:wire(Anchor, #event { show_if=(not ShowButton), type=change, delegate=?MODULE, postback=StartedTag }),
@@ -126,7 +126,8 @@ event({upload_finished, Record}) ->
     % Make the tag...
     Anchor = wf_context:anchor(),
     ValidationGroup = wf_context:event_validation_group(),
-    Postback = wf_event:generate_postback_script(NewTag, Anchor, ValidationGroup, ?MODULE, undefined),
+    HandleInvalid = wf_context:event_handle_invalid(),
+    Postback = wf_event:generate_postback_script(NewTag, Anchor, ValidationGroup, HandleInvalid, undefined, ?MODULE, undefined),
 
     % Set the response...
     wf_context:data([

--- a/src/elements/html/element_link.erl
+++ b/src/elements/html/element_link.erl
@@ -13,7 +13,13 @@ render_element(Record) ->
     Anchor = Record#link.anchor,
     case Record#link.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=click, postback=Postback, validation_group=ID, delegate=Record#link.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=click,
+                    postback=Postback,
+                    validation_group=ID,
+                    handle_invalid=Record#link.handle_invalid,
+                    on_invalid=Record#link.on_invalid,
+                    delegate=Record#link.delegate })
     end,
 
     Body = [

--- a/src/elements/other/element_dropdown.erl
+++ b/src/elements/other/element_dropdown.erl
@@ -13,7 +13,13 @@ render_element(Record) ->
     Anchor = Record#dropdown.anchor,
     case Record#dropdown.postback of
         undefined -> ignore;
-        Postback -> wf:wire(Anchor, #event { type=change, postback=Postback, validation_group=ID, delegate=Record#dropdown.delegate })
+        Postback -> wf:wire(Anchor, #event {
+                    type=change,
+                    postback=Postback,
+                    validation_group=ID,
+                    handle_invalid=Record#dropdown.handle_invalid,
+                    on_invalid=Record#dropdown.on_invalid,
+                    delegate=Record#dropdown.delegate })
     end,
 
     case Record#dropdown.value of 

--- a/src/elements/other/element_droppable.erl
+++ b/src/elements/other/element_droppable.erl
@@ -13,7 +13,7 @@ render_element(Record) ->
     Delegate = Record#droppable.delegate,
     Tag = Record#droppable.tag,
     Anchor = Record#droppable.anchor,
-    PostbackInfo = wf_event:serialize_event_context({Delegate, Tag}, Anchor, undefined, ?MODULE),
+    PostbackInfo = wf_event:serialize_event_context({Delegate, Tag}, Anchor, undefined, false, ?MODULE),
     ActiveClass = Record#droppable.active_class, 
     HoverClass = Record#droppable.hover_class,
     AcceptGroups = groups_to_accept(Record#droppable.accept_groups),

--- a/src/elements/other/element_sortblock.erl
+++ b/src/elements/other/element_sortblock.erl
@@ -13,7 +13,7 @@ render_element(Record) ->
     Anchor = Record#sortblock.anchor,
     Tag = Record#sortblock.tag,
     Delegate = Record#sortblock.delegate,
-    PostbackInfo = wf_event:serialize_event_context({Delegate, Tag}, Anchor, undefined, ?MODULE),
+    PostbackInfo = wf_event:serialize_event_context({Delegate, Tag}, Anchor, undefined, false, ?MODULE),
     Handle = case Record#sortblock.handle of
         undefined -> "null";
         Other -> wf:f("'.~s'", [Other])

--- a/src/elements/other/element_textbox_autocomplete.erl
+++ b/src/elements/other/element_textbox_autocomplete.erl
@@ -13,8 +13,8 @@ render_element(Record) ->
     AutoCompleteDelay = Record#textbox_autocomplete.delay,
     
     % Write out the script to make this element autocompletable...
-    AutoCompleteEnterPostbackInfo = wf_event:serialize_event_context({autocomplete_enter_event, Delegate, Tag}, Anchor, undefined, ?MODULE),
-    AutoCompleteSelectPostbackInfo = wf_event:serialize_event_context({autocomplete_select_event, Delegate, Tag }, Anchor, undefined, ?MODULE ),
+    AutoCompleteEnterPostbackInfo = wf_event:serialize_event_context({autocomplete_enter_event, Delegate, Tag}, Anchor, undefined, false, ?MODULE),
+    AutoCompleteSelectPostbackInfo = wf_event:serialize_event_context({autocomplete_select_event, Delegate, Tag }, Anchor, undefined, false, ?MODULE),
     
     AutoCompleteOptions = {struct, [
         {dataType, <<"json">>},

--- a/src/lib/wf_context.erl
+++ b/src/lib/wf_context.erl
@@ -201,6 +201,14 @@ event_validation_group(ValidationGroup) ->
     Event = event_context(),
     event_context(Event#event_context { validation_group = ValidationGroup }).
 
+event_handle_invalid() ->
+    Event = event_context(),
+    Event#event_context.handle_invalid.
+
+event_handle_invalid(HandleInvalid) ->
+    Event = event_context(),
+    event_context(Event#event_context { handle_invalid = HandleInvalid }).
+
 
 
 %%% HANDLERS %%%

--- a/src/lib/wf_event.erl
+++ b/src/lib/wf_event.erl
@@ -6,9 +6,9 @@
 -include_lib ("wf.hrl").
 -export ([
     update_context_with_event/0,
-    generate_postback_script/5,
-    generate_system_postback_script/4,
-    serialize_event_context/4
+    generate_postback_script/7,
+    generate_system_postback_script/5,
+    serialize_event_context/5
 ]).
 
 % This module looks at the incoming request for 'eventContext' and 'pageContext' params. 
@@ -46,28 +46,39 @@ update_context_for_first_request() ->
 update_context_for_postback_request(Event) ->
     Anchor = Event#event_context.anchor,
     ValidationGroup = Event#event_context.validation_group,
+    HandleInvalid = Event#event_context.handle_invalid,
     wf_context:type(postback_request),
     wf_context:event_context(Event),
     wf_context:anchor(Anchor),
     wf_context:event_validation_group(ValidationGroup),
+    wf_context:event_handle_invalid(HandleInvalid),
     ok.
 
-generate_postback_script(undefined, _Anchor, _ValidationGroup, _Delegate, _ExtraParam) -> [];
-generate_postback_script(Postback, Anchor, ValidationGroup, Delegate, ExtraParam) ->
-    PickledPostbackInfo = serialize_event_context(Postback, Anchor, ValidationGroup, Delegate),
-    wf:f("Nitrogen.$queue_event('~s', '~s', ~s);", [ValidationGroup, PickledPostbackInfo, ExtraParam]).
+generate_postback_script(undefined, _Anchor, _ValidationGroup, _HandleInvalid, _OnInvalid, _Delegate, _ExtraParam) -> [];
+generate_postback_script(Postback, Anchor, ValidationGroup, HandleInvalid, OnInvalid, Delegate, ExtraParam) ->
+    PickledPostbackInfo = serialize_event_context(Postback, Anchor, ValidationGroup, HandleInvalid, Delegate),
+    OnInvalidScript = case OnInvalid of
+        undefined -> "null";
+        _         -> ["function(){", OnInvalid, "}"]
+    end,
+    [
+        wf:f("Nitrogen.$queue_event('~s', ", [ValidationGroup]),
+        OnInvalidScript,
+        wf:f(", '~s', ~s);", [PickledPostbackInfo, ExtraParam])
+    ].
 
-generate_system_postback_script(undefined, _Anchor, _ValidationGroup, _Delegate) -> [];
-generate_system_postback_script(Postback, Anchor, ValidationGroup, Delegate) ->
-    PickledPostbackInfo = serialize_event_context(Postback, Anchor, ValidationGroup, Delegate),
+generate_system_postback_script(undefined, _Anchor, _ValidationGroup, _HandleInvalid, _Delegate) -> [];
+generate_system_postback_script(Postback, Anchor, ValidationGroup, HandleInvalid, Delegate) ->
+    PickledPostbackInfo = serialize_event_context(Postback, Anchor, ValidationGroup, HandleInvalid, Delegate),
     wf:f("Nitrogen.$queue_system_event('~s');", [PickledPostbackInfo]).
 
-serialize_event_context(Tag, Anchor, ValidationGroup, Delegate) ->
+serialize_event_context(Tag, Anchor, ValidationGroup, HandleInvalid, Delegate) ->
     PageModule = wf_context:page_module(),
     EventModule = wf:coalesce([Delegate, PageModule]),
     Event = #event_context {
         module = EventModule,
         tag = Tag,
+        handle_invalid = HandleInvalid,
         anchor = Anchor,
         validation_group = ValidationGroup
     },

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -172,6 +172,7 @@ run_postback_request() ->
     % Some values...
     Module = wf_context:event_module(),
     Tag = wf_context:event_tag(),
+    HandleInvalid = wf_context:event_handle_invalid(),
 
     % Validate...
     {ok, IsValid} = wf_validation:validate(),
@@ -179,7 +180,11 @@ run_postback_request() ->
     % Call the event...
     case IsValid of
         true -> Module:event(Tag);
-        false -> ok
+        false ->
+            if
+                HandleInvalid -> Module:event_invalid(Tag);
+                true          -> ok
+            end
     end.
 
 %%% BUILD THE RESPONSE %%%


### PR DESCRIPTION
This change introduces handling of two more cases that occurs when using validators, as well as fixes a bug in nitrogen.js.

Usually postback validation can be seen as having 3 general steps: client side validation, server side validation and invoke event. In the current state, if either client side validation or server side validation evaluates to false, the possibilities of managing these states are limited. It's either no event, or event.

This change introduces possibilities to manage these two cases.

One is done by adding an extra parameter to the `#event_context` record - a boolean telling if a server side validator evaluated to false, should or should not the state be handled. If set to true (which is done by specifying for example `#link{..., postback = foo, handle_invalid = true, ...}` or `#event{..., postback = bar, handle_invalid = true, ...}`). In case an event has been specified to be handled even if the validator evaluated to false, instead of invoking the event via `Delegate:event(Tag)`, it's invoked via `Delegate:event_invalid(Tag)`.

The other addition is to handle the case where the client side validation evaluates to false. This is done in a similar manner by specifying what actions should be executed in case the validation fails, for example `#link{..., postback = foo, on_invalid = #hide{target = spinner}, ...}` or similar to any `#event{...}`. This is implemented by passing this script down to `$queue_event` and finally to `$do_event` in nitrogen.js.

The bug fix mentioned is on line 84 in nitrogen.js (https://github.com/jadahl/nitrogen_core/commit/0643f69edaaf27bdfee16610883032cc6eb03c85#L17L84). It fixes a bug causing client side validation to always fail.
