### PR TITLE
Make labels for radio and checkboxes 'clickable'

### DIFF
--- a/src/elements/forms/element_checkbox.erl
+++ b/src/elements/forms/element_checkbox.erl
@@ -25,6 +25,7 @@ render_element(Record) ->
         % Checkbox...
         wf_tags:emit_tag(input, [
             {name, Anchor},
+            {id, Anchor},
             {type, checkbox},
             {class, [checkbox, Record#checkbox.class]},
             {style, Record#checkbox.style},

--- a/src/elements/forms/element_radio.erl
+++ b/src/elements/forms/element_radio.erl
@@ -27,7 +27,7 @@ render_element(Record) ->
         %% Checkbox...
         wf_tags:emit_tag(input, [
             {name, Record#radio.name},
-            {id, ID},
+            {id, Anchor},
             {value, Record#radio.value},
             {type, radio},
             {class, [radio, Record#radio.class]},
@@ -37,6 +37,6 @@ render_element(Record) ->
 
         %% Label for Radio...
         wf_tags:emit_tag(label, Content, [
-            {for, ID}
+            {for, Anchor}
         ])
     ].


### PR DESCRIPTION
When using labels in HTML forms, the label is "clickable" (i.e. when the label is clicked the form control associated with it behaves as if it has been clicked) when the for attribute in the label element corresponds to the id attribute of the form field element.

Previously the radio and checkbox element labels in Nitrogen 2.x were not clickable because the radio button and checkbox markup did not have an id set that corresponded to the for attribute of the associated label. These changes fix that.
