### PR TITLE
is_integer validator didn't implement render_action/1

### DIFF
--- a/src/validators/validator_is_integer.erl
+++ b/src/validators/validator_is_integer.erl
@@ -6,10 +6,14 @@
 -include_lib ("wf.hrl").
 -compile(export_all).
 
-render_validator(TriggerPath, TargetPath, Record) -> 
+render_action(Record) ->
+    TriggerPath = Record#is_integer.trigger,
+    TargetPath = Record#is_integer.target,
     Text = wf:js_escape(Record#is_integer.text),
-    validator_custom:render_validator(TriggerPath, TargetPath, #custom { function=fun validate/2, text = Text, tag=Record }),
-    wf:f("v.add(Validate.Numericality, { notAnIntegerMessage: \"~s\", onlyInteger: true });", [Text]).
+    CustomValidatorAction =  #custom { trigger=TriggerPath, target=TargetPath, function=fun validate/2, text = Text, tag=Record },
+    Script = wf:f("v.add(Validate.Numericality, { notAnIntegerMessage: \"~s\", onlyInteger: true });", [Text]),
+    [CustomValidatorAction, Script].
+    
 
 validate(_, Value) -> 
     try is_integer(list_to_integer(Value)) == true


### PR DESCRIPTION
All validators should implement and export render_action/1. validator_is_integer implemented render_validator/3. I copied the render_action scheme from validator_is_required.erl and tested the code manually with a nitrogen page similar to the validator demo on nitrogenproject.com.
