### PR TITLE
fix app name in default_config_handler.erl

### DIFF
--- a/src/handlers/config/default_config_handler.erl
+++ b/src/handlers/config/default_config_handler.erl
@@ -28,7 +28,7 @@ get_value(Key, DefaultValue, Config, State) ->
     end.
 
 get_values(Key, DefaultValue, _Config, _State) -> 
-    case application:get_env(nitrogen, Key) of
+    case application:get_env(nitrogen_core, Key) of
         {ok, Value} -> 
             [Value];
         undefined ->


### PR DESCRIPTION
the app name is nitrogen_core so the calls to application:get_env should use the same key, otherwise things don't work.
