### PR TITLE
add module_prefix config setting to dynamic_route_handler

### DIFF
--- a/src/handlers/route/dynamic_route_handler.erl
+++ b/src/handlers/route/dynamic_route_handler.erl
@@ -54,7 +54,7 @@ finish(_Config, State) ->
 % First, cycle through code:all_loaded(). If not there, then check erl_prim_loader:get_file()
 % If still not there, then 404.
 route("/") -> 
-    {index, []};
+    {list_to_atom(module_name(["index"])), []};
 
 route(Path) ->
     IsStatic = (filename:extension(Path) /= []),
@@ -92,11 +92,19 @@ route(Path) ->
 %%             find_loaded_module(tl(lists:reverse(Tokens)), [hd(lists:reverse(Tokens))|ExtraTokens])
 %%     end.
 
+module_name(Tokens) ->
+	ModulePrefix = wf:config_default(module_prefix, ""),
+	AllTokens = case ModulePrefix of
+		"" -> Tokens;
+		_ -> [ ModulePrefix | Tokens ]
+		end,
+	ModuleName = string:join(AllTokens, "_").
+
 try_load_module(Tokens) -> try_load_module(Tokens, []).
 try_load_module([], _ExtraTokens) -> undefined;
 try_load_module(Tokens, ExtraTokens) ->
     %% Get the module name...
-    ModuleName = string:join(Tokens, "_"),
+    ModuleName = module_name(Tokens),
     Module = try 
         list_to_existing_atom(ModuleName)
     catch _:_ ->


### PR DESCRIPTION
Hi. This one allows you to set module_prefix in the configuration and makes dynamic handler respect that. For example, if you set { module_prefix, "path" } then it will look for "path_index" for the root, and "path_users" for "/users". If this config option is absent then it should behave exactly as before. I guess I could do this by setting my own handler, but it seems like the kind of thing which ought to be included by default.
