### PR TITLE
Convert #template bindings to expected orddict

### DIFF
--- a/src/elements/layout/element_template.erl
+++ b/src/elements/layout/element_template.erl
@@ -1,3 +1,4 @@
+% vim: sw=4 ts=4 et
 % Nitrogen Web Framework for Erlang
 % Copyright (c) 2008-2010 Rusty Klophaus
 % See MIT-LICENSE for licensing information.
@@ -124,9 +125,12 @@ peel([H|T], Delim, Acc) -> peel(T, Delim, [H|Acc]).
 
 to_term(X, Bindings) ->
     S = wf:to_list(X),
+    %% erl_eval:exprs/2 expects Bindings to be an orddict, but Nitrogen 
+    %% does not have this requirement, so let's fix that.
+    OrdDictBindings = orddict:from_list(Bindings),
     {ok, Tokens, 1} = erl_scan:string(S),
     {ok, Exprs} = erl_parse:parse_exprs(Tokens),
-    {value, Value, _} = erl_eval:exprs(Exprs, Bindings),
+    {value, Value, _} = erl_eval:exprs(Exprs, OrdDictBindings),
     Value.
 
 


### PR DESCRIPTION
Fixes bug if template bindings are not sent as an orddict.
