### PR TITLE
Corrected range elements field name from data to data_fields

### DIFF
--- a/src/elements/forms/element_range.erl
+++ b/src/elements/forms/element_range.erl
@@ -33,5 +33,5 @@ render_element(Record) ->
         {style, Record#range.style},
         {id, Record#range.html_id},
         {value, Record#range.value},
-        {data, Record#range.data_fields}
+        {data_fields, Record#range.data_fields}
     ]).


### PR DESCRIPTION
There was an error generating range element when the fields name was data.
