### PR TITLE
Create the bindings orddict just once instead for every eval call down the chain in template elements

### DIFF
--- a/src/elements/layout/element_template.erl
+++ b/src/elements/layout/element_template.erl
@@ -29,7 +29,7 @@ render_element(Record) ->
     %% create the needed Ord-Dict just once instead for every eval call down the chain
     OrdDictBindings = orddict:from_list(Record#template.bindings),
     Fixed_bindings_record = Record#template{bindings=OrdDictBindings},
-    Body = eval(Template, Record),
+    Body = eval(Template, Fixed_bindings_record),
     Body.
 
 get_cached_template(File) ->


### PR DESCRIPTION
Please review.
Save a few cycles and as well some bytes in case of larger binding content
(graph data f.e.)
