### PR TITLE
#dropdown{} option change

### DIFF
--- a/src/elements/forms/element_dropdown.erl
+++ b/src/elements/forms/element_dropdown.erl
@@ -105,7 +105,7 @@ create_options(_,_,[Other | _]) ->
     throw({unknown_option_provided_to_dropdown_element,Other}).
 
 selected_or_not(Selected,X) ->
-    case (Selected =/= undefined andalso wf:to_list(X#option.value) == Selected)
+    case (Selected =/= [] andalso wf:to_list(X#option.value) == Selected)
             orelse X#option.selected == true of
         true -> selected;
         false -> not_selected


### PR DESCRIPTION
Hi,

  This is really minor change and considered not even doing a pull request for it.

  But if you use some restful forms/don't populate the value field of dropdown it can cause problems.

  This can be seen at the dropdown at http://nitrogenproject.com/demos/simplecontrols where the html renders everything as selected.

"
<select class="wfid_temp145757 dropdown"><option selected="">Dropdown</option><option selected="">Option 1</option><option selected="">Option 2</option><option selected="">Option 3</option></select>
"

  This is due the function selected_or_not/2 being passed Selected as [] instead of what it was trying to check i.e. undefined. And as you might not have filled in the value feild therefore it would be [] and match Selected.

  Hope this change request is not too minor, as I realise that it can be bypassed by using value and not only the text field of the #option{}.

Thanks Jesse.
