### PR TITLE
js output must use ~ts instead of ~s

### DIFF
--- a/src/actions/action_alert.erl
+++ b/src/actions/action_alert.erl
@@ -8,4 +8,4 @@
 -compile(export_all).
 
 render_action(Record) -> 
-    wf:f("window.alert(\"~s\");", [wf:js_escape(Record#alert.text)]).	
+    wf:f("window.alert(\"~ts\");", [wf:js_escape(Record#alert.text)]).	

--- a/src/actions/action_before_postback.erl
+++ b/src/actions/action_before_postback.erl
@@ -4,4 +4,4 @@
 -export([render_action/1]).
 
 render_action(#before_postback{script=Script}) ->
-    wf:f("Nitrogen.$before_postback(function(){ ~s });",[Script]).
+    wf:f("Nitrogen.$before_postback(function(){ ~ts });",[Script]).

--- a/src/actions/action_clear_validation.erl
+++ b/src/actions/action_clear_validation.erl
@@ -41,19 +41,19 @@ clear_specific_validators(Trigger, Target) ->
 	Validators = get_validators(),
 	FilteredValidators = [X || X={ValGroup, ValPath, _} <- Validators, not(ValGroup==Trigger andalso ValPath==Target)],
 	set_validators(FilteredValidators),
-	wf:f("Nitrogen.$destroy_specific_validation('~s','~s')",[Trigger, Target]).
+	wf:f("Nitrogen.$destroy_specific_validation('~ts','~ts')",[Trigger, Target]).
 
 clear_target_validators(Target) ->
 	Validators = get_validators(),
 	FilteredValidators = [X || X={_, ValPath, _} <- Validators, ValPath =/= Target],
 	set_validators(FilteredValidators),
-	wf:f("Nitrogen.$destroy_target_validation('~s')",[Target]).
+	wf:f("Nitrogen.$destroy_target_validation('~ts')",[Target]).
 	
 clear_trigger_validators(Trigger) ->
 	Validators = get_validators(),
 	FilteredValidators = [X || X={ValGroup, _, _} <- Validators, ValGroup =/= Trigger],
 	set_validators(FilteredValidators),
-	wf:f("Nitrogen.$destroy_validation_group('~s')",[Trigger]).
+	wf:f("Nitrogen.$destroy_validation_group('~ts')",[Trigger]).
 
 
 get_validators() ->

--- a/src/actions/action_confirm.erl
+++ b/src/actions/action_confirm.erl
@@ -12,7 +12,7 @@ render_action(Record) ->
     TargetPath = Record#confirm.target,
     Delegate = Record#confirm.delegate,
     [
-        wf:f("if (confirm(\"~s\")) {", [wf:js_escape(Record#confirm.text)]),
+        wf:f("if (confirm(\"~ts\")) {", [wf:js_escape(Record#confirm.text)]),
         #event { postback=Record#confirm.postback, trigger=TriggerPath, target=TargetPath, delegate=Delegate },
         Record#confirm.actions,
         "}"

--- a/src/actions/action_console_log.erl
+++ b/src/actions/action_console_log.erl
@@ -13,9 +13,9 @@
 
 -spec render_action(Record :: tuple()) -> binary().
 render_action(#console_log{text=Text}) ->
-    Text2 = ?WF_IF(?IS_STRING(Text) orelse is_binary(Text),Text,wf:f("~p",[Text])),
+    Text2 = ?WF_IF(?IS_STRING(Text) orelse is_binary(Text),Text,wf:f("~ts",[Text])),
     JsText = wf:js_escape(wf:to_list(Text2)),
-    wf:f(<<"Nitrogen.$console_log(\"~s\");">>, [JsText]).
+    wf:f(<<"Nitrogen.$console_log(\"~ts\");">>, [JsText]).
 
 -spec console_log(Value :: string() | any()) -> ok.
 console_log(Value) ->

--- a/src/actions/action_redirect.erl
+++ b/src/actions/action_redirect.erl
@@ -16,12 +16,12 @@
 -spec render_action(#redirect{}) -> text().
 render_action(Record) ->
     DestinationUrl = Record#redirect.url,
-    wf:f("window.location=\"~s\";", [wf:js_escape(DestinationUrl)]).
+    wf:f("window.location=\"~ts\";", [wf:js_escape(DestinationUrl)]).
 
 -spec redirect(url()) -> html().
 redirect(Url) -> 
     wf:wire(#redirect { url=Url }),
-    wf:f("<script>window.location=\"~s\";</script>", [wf:js_escape(Url)]).
+    wf:f("<script>window.location=\"~ts\";</script>", [wf:js_escape(Url)]).
 
 -spec redirect_to_login(url(), url()) -> html().
 redirect_to_login(LoginUrl, PostLoginUrl) ->

--- a/src/actions/action_set_cookie.erl
+++ b/src/actions/action_set_cookie.erl
@@ -7,4 +7,4 @@ render_action(#set_cookie{cookie=Cookie0, value=Value0, path=Path0, minutes_to_l
 	Value = wf:js_escape(Value0),
 	Path = wf:js_escape(Path0),
 	Mins = wf:to_list(Mins0),
-	wf:f(<<"Nitrogen.$set_cookie('~s','~s','~s','~s');">>,[Cookie, Value, Path, Mins]).
+	wf:f(<<"Nitrogen.$set_cookie('~ts','~ts','~ts','~ts');">>,[Cookie, Value, Path, Mins]).

--- a/src/actions/action_set_multiple.erl
+++ b/src/actions/action_set_multiple.erl
@@ -13,13 +13,13 @@
 
 render_action(#set_multiple{anchor=Anchor, target=Target, values=Values0}) ->
     Values = format_values(Values0),
-    wf:f(<<"Nitrogen.$set_values('~s', '~s', [~s]);">>, [Anchor, Target, Values]).
+    wf:f(<<"Nitrogen.$set_values('~s', '~s', [~ts]);">>, [Anchor, Target, Values]).
 
 format_values(Vs) ->
     wf:join([format_value(V) || V <- Vs], <<", ">>).
 
 format_value(V) ->
-    wf:f("'~s'", [wf:js_escape(wf:to_list(V))]).
+    wf:f("'~ts'", [wf:js_escape(wf:to_list(V))]).
 
 set(Element, Values) when is_list(Values) ->
 	set(normal, Element, Values).

--- a/src/validators/validator_is_email.erl
+++ b/src/validators/validator_is_email.erl
@@ -20,7 +20,7 @@ render_action(Record)  ->
         target=TargetPath, 
         function=fun validate/2, text = Text, tag=Record, attach_to=Record#is_email.attach_to
     }),
-    wf:f("v.add(Validate.Email, { failureMessage: \"~s\" });", [Text]).
+    wf:f("v.add(Validate.Email, { failureMessage: \"~ts\" });", [Text]).
 
 -spec validate(any(), iolist()) -> boolean().
 validate(_, Value) ->

--- a/src/validators/validator_is_integer.erl
+++ b/src/validators/validator_is_integer.erl
@@ -27,7 +27,7 @@ render_action(Record) ->
         attach_to=Record#is_integer.attach_to
     },
 
-    Script = wf:f("v.add(Validate.Numericality, { notAnIntegerMessage: \"~s\", onlyInteger: true });", [Text]),
+    Script = wf:f("v.add(Validate.Numericality, { notAnIntegerMessage: \"~ts\", onlyInteger: true });", [Text]),
     [CustomValidatorAction, Script].
 
 validate(Value, Min, Max) ->

--- a/src/validators/validator_js_custom.erl
+++ b/src/validators/validator_js_custom.erl
@@ -12,4 +12,4 @@ render_action(Record) ->
     Function = Record#js_custom.function,
     Args = Record#js_custom.args,
     WhenEmpty = Record#js_custom.when_empty,
-    wf:f("v.add(Validate.Custom, { against: ~s, args: ~s, failureMessage: \"~s\", displayMessageWhenEmpty: ~s });", [Function, Args, Text, WhenEmpty]).
+    wf:f("v.add(Validate.Custom, { against: ~s, args: ~ts, failureMessage: \"~ts\", displayMessageWhenEmpty: ~ts });", [Function, Args, Text, WhenEmpty]).

--- a/src/validators/validator_max_length.erl
+++ b/src/validators/validator_max_length.erl
@@ -15,7 +15,7 @@ render_action(Record)  ->
     Length = Record#max_length.length,
     CustomValidatorAction = #custom { trigger=TriggerPath, target=TargetPath, function=fun validate/2, text=Text, tag=Record, attach_to=Record#max_length.attach_to },
     validator_custom:render_action(CustomValidatorAction),
-    wf:f("v.add(Validate.Length, { maximum: ~p, tooLongMessage: \"~s\" });", [Length, Text]).
+    wf:f("v.add(Validate.Length, { maximum: ~p, tooLongMessage: \"~ts\" });", [Length, Text]).
 
 validate(Record, Value) ->
     Record#max_length.length >= length(Value).

--- a/src/validators/validator_min_length.erl
+++ b/src/validators/validator_min_length.erl
@@ -13,7 +13,7 @@ render_action(Record)  ->
     Text = wf:js_escape(Record#min_length.text),
     Length = Record#min_length.length,
     validator_custom:render_action(#custom { trigger=TriggerPath, target=TargetPath, function=fun validate/2, text = Text, tag=Record, attach_to=Record#min_length.attach_to }),
-    wf:f("v.add(Validate.Length, { minimum: ~p, tooShortMessage: \"~s\" });", [Length, Text]).
+    wf:f("v.add(Validate.Length, { minimum: ~p, tooShortMessage: \"~ts\" });", [Length, Text]).
 
 validate(Record, Value) ->
     Record#min_length.length =< length(Value).


### PR DESCRIPTION
some place must to be used `~ts` instead of `~s` for unicode : )

for example:
```` erlang
render_action(Record)  ->
    TriggerPath= Record#min_length.trigger,
    ....
    wf:f("v.add(Validate.Length, { minimum: ~p, tooShortMessage: \"~s\" });", [Length, Text]).
````
The code above can't generate proper unicode string, and it must rewrite as this:
```` erlang
    wf:f("v.add(Validate.Length, { minimum: ~p, tooShortMessage: \"~ts\" });", [Length, Text]).
````