### PR TITLE
Change to the way time is outputed

### DIFF
--- a/src/elements/html5/element_time.erl
+++ b/src/elements/html5/element_time.erl
@@ -15,7 +15,8 @@ reflect() -> record_info(fields, time).
 -spec render_element(#time{}) -> body().
 render_element(Record) ->
     Text = wf:html_encode(Record#time.text, Record#time.html_encode),
-    wf_tags:emit_tag(time, [Text, Record#time.body], [
+    wf_tags:emit_tag(input, [Text, Record#time.body], [
+        {type, time},
         {id, Record#time.html_id},
         {class, ["time", Record#time.class]},
         {title, Record#time.title},


### PR DESCRIPTION
HI Jesse,

As this elements is in html5 directory I believe it should be outputted as html5 element it seems to be outputed as (http://www.w3schools.com/tags/tag_time.asp). 

I think it should be outputted as http://www.w3schools.com/html/tryit.asp?filename=tryhtml_input_time

It is notably not supported on firefox or internet explorer; on firefox it shows as a text input. Don't run windows at the moment so not sure how it would look/behave on internet explorer but I believe it would be similar.

Regards,
Stuart