### PR TITLE
Erlang 21 Support

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -317,8 +317,7 @@
         on_invalid              :: undefined | actions(),
         delegate                :: module(),
         html_name               :: html_name(),
-        type=text               :: string() | atom(),
-        autocomplete="on"       :: string() | atom()
+        type=text               :: string() | atom()
     }).
 -record(datepicker_textbox, {?ELEMENT_BASE(element_datepicker_textbox),
         text=""                 :: text(),

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -317,7 +317,8 @@
         on_invalid              :: undefined | actions(),
         delegate                :: module(),
         html_name               :: html_name(),
-        type=text               :: string() | atom()
+        type=text               :: string() | atom(),
+        autocomplete="on"       :: string() | atom()
     }).
 -record(datepicker_textbox, {?ELEMENT_BASE(element_datepicker_textbox),
         text=""                 :: text(),

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -317,7 +317,8 @@
         on_invalid              :: undefined | actions(),
         delegate                :: module(),
         html_name               :: html_name(),
-        type=text               :: string() | atom()
+        type=text               :: string() | atom(),
+	autocomplete="off"      :: string() | atom()
     }).
 -record(datepicker_textbox, {?ELEMENT_BASE(element_datepicker_textbox),
         text=""                 :: text(),
@@ -946,11 +947,6 @@
 -record(js_fun, {?ACTION_BASE(action_js_fun),
         function                :: atom() | text(),
         args=[]                 :: [text()]
-    }).
--record(if_value, {?ACTION_BASE(action_if_value),
-        value                   :: atom() | text(),
-        map                     :: undefined | [{atom() | text(), actions()}],
-        else=[]                 :: actions()
     }).
 -record(set, {?ACTION_BASE(action_set),
         value=""                :: text() | integer()

--- a/src/elements/forms/element_textbox.erl
+++ b/src/elements/forms/element_textbox.erl
@@ -31,6 +31,7 @@ render_element(Record) ->
     Attributes = [
         {id, Record#textbox.html_id},
         {type, Record#textbox.type}, 
+	{autocomplete,Record#textbox.autocomplete},
         {class, [textbox, Record#textbox.class]},
         {title, Record#textbox.title},
         {maxlength, Record#textbox.maxlength},

--- a/src/handlers/query/default_query_handler.erl
+++ b/src/handlers/query/default_query_handler.erl
@@ -32,8 +32,8 @@ init(_Config, _State) ->
     % Get query params and post params
     % from the request bridge...
     RequestBridge = wf_context:bridge(),
-    QueryParams = apply(element(1,RequestBridge),query_params,RequestBridge).
-    PostParams = apply(element(1,RequestBridge),post_params,RequestBridge).
+    QueryParams = apply(element(1,RequestBridge),query_params,RequestBridge),
+    PostParams = apply(element(1,RequestBridge),post_params,RequestBridge),
 
     % Load into state...
     Params = QueryParams ++ PostParams,

--- a/src/handlers/query/default_query_handler.erl
+++ b/src/handlers/query/default_query_handler.erl
@@ -32,8 +32,8 @@ init(_Config, _State) ->
     % Get query params and post params
     % from the request bridge...
     RequestBridge = wf_context:bridge(),
-    QueryParams = apply(element(1,RequestBridge),query_params,RequestBridge),
-    PostParams = apply(element(1,RequestBridge),post_params,RequestBridge),
+    QueryParams = apply(element(1,RequestBridge),query_params,[RequestBridge]),
+    PostParams = apply(element(1,RequestBridge),post_params,[RequestBridge]),
 
     % Load into state...
     Params = QueryParams ++ PostParams,

--- a/src/handlers/query/default_query_handler.erl
+++ b/src/handlers/query/default_query_handler.erl
@@ -32,8 +32,8 @@ init(_Config, _State) ->
     % Get query params and post params
     % from the request bridge...
     RequestBridge = wf_context:bridge(),
-    QueryParams = RequestBridge:query_params(),
-    PostParams = RequestBridge:post_params(),
+    QueryParams = apply(element(1,RequestBridge),query_params,RequestBridge).
+    PostParams = apply(element(1,RequestBridge),post_params,RequestBridge).
 
     % Load into state...
     Params = QueryParams ++ PostParams,

--- a/src/lib/wf_context.erl
+++ b/src/lib/wf_context.erl
@@ -127,19 +127,19 @@ in_request() ->
 
 socket() ->
     Req = request_bridge(),
-    apply(element(1,Req),socket,Req).
+    apply(element(1,Req),socket,[Req]).
 
 path() ->
     Req = request_bridge(),
-    apply(element(1,Req),path,Req).
+    apply(element(1,Req),path,[Req]).
 
 protocol() ->
     Req = request_bridge(),
-    apply(element(1,Req),protocol,Req).
+    apply(element(1,Req),protocol,[Req]).
 
 uri() ->
     Req = request_bridge(),
-    apply(element(1,Req),uri,Req).
+    apply(element(1,Req),uri,[Req]).
 
 url() ->
     Protocol = wf:to_list(protocol()),
@@ -149,7 +149,7 @@ url() ->
 
 peer_ip() ->
     Req = request_bridge(),
-    apply(element(1,Req),peer_ip,Req).
+    apply(element(1,Req),peer_ip,[Req]).
 
 
 peer_ip(Proxies) ->
@@ -172,7 +172,7 @@ peer_ip(Proxies,ForwardedHeader) ->
 
 request_method() ->
     Req = request_bridge(),
-    case apply(element(1,Req),request_method,Req) of
+    case apply(element(1,Req),request_method,[Req]) of
         'GET'       -> get;
         get         -> get;
         'POST'      -> post;
@@ -194,11 +194,11 @@ request_method() ->
 
 request_body() ->
     Req = request_bridge(),
-    apply(element(1,Req),request_body,Req).
+    apply(element(1,Req),request_body,[Req]).
 
 status_code() ->
     Req = request_bridge(),
-    apply(element(1,Req),status_code,Req).
+    apply(element(1,Req),status_code,[Req]).
 
 status_code(StatusCode) ->
     Req = request_bridge(),
@@ -221,7 +221,7 @@ download_as(Filename0) ->
 
 headers() ->
     Req = request_bridge(),
-    apply(element(1,Req),headers,Req).
+    apply(element(1,Req),headers,[Req]).
 
 header(Header) ->
     Req = request_bridge(),

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -19,7 +19,7 @@
 run() ->
     Bridge = wf_context:bridge(),
     try 
-        case Bridge:error() of
+        case Bridge:error(Bridge) of
             none -> run_catched();
             Other -> 
                 Message = wf:f("Errors: ~p~n", [Other]),
@@ -333,4 +333,3 @@ encoding_by_content_type(<<"application/csv">>) ->
     unicode;
 encoding_by_content_type(_) ->
     none.
-

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -23,8 +23,8 @@ run() ->
             none -> run_catched();
             Other -> 
                 Message = wf:f("Errors: ~p~n", [Other]),
-                Bridge1 = Bridge:set_response_data(Message),
-                Bridge1:build_response()
+                Bridge1 = apply(element(1,Bridge),set_response_data,Message), 
+		apply(element(1,Bridge1),set_response_data,[])
         end
     catch
         exit:normal ->

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -19,7 +19,7 @@
 run() ->
     Bridge = wf_context:bridge(),
     try 
-        case Bridge:error(Bridge) of
+        case apply(element(1,Bridge),error,Bridge) of
             none -> run_catched();
             Other -> 
                 Message = wf:f("Errors: ~p~n", [Other]),

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -19,11 +19,11 @@
 run() ->
     Bridge = wf_context:bridge(),
     try 
-        case apply(element(1,Bridge),error,Bridge) of
+        case apply(element(1,Bridge),error,[Bridge]) of
             none -> run_catched();
             Other -> 
                 Message = wf:f("Errors: ~p~n", [Other]),
-                Bridge1 = apply(element(1,Bridge),set_response_data,Message), 
+                Bridge1 = apply(element(1,Bridge),set_response_data,[Message]), 
 		apply(element(1,Bridge1),set_response_data,[])
         end
     catch


### PR DESCRIPTION
It seems Erlang 21 removed the support to apply records to function names, created workaround that takes first element as module and pass the record to the Args. 