### PR TITLE
update bert.js to encode *undefined* value to the *undefined* atom

### DIFF
--- a/www/bert.js
+++ b/www/bert.js
@@ -173,6 +173,10 @@ BertClass.prototype.encode_boolean = function (Obj) {
 	}
 };
 
+BertClass.prototype.encode_undefined = function (Obj) {
+	return this.encode_inner(this.atom("undefined"));
+}
+
 BertClass.prototype.encode_number = function (Obj) {
 	var s, isInteger = (Obj % 1 === 0);
 


### PR DESCRIPTION
This simplifies exchanging nil values between the viewport and the
server. I picked *undefined* because it is already used in erlang.

My use case consisted of an #api querying to send some js variable. Before this the js undefined value was passed as "undefined" -the list-. With this, undefined values will be sent as *undefined* (the atom).