### PR TITLE
added nonce to <script> for content-security-policy use

### DIFF
--- a/src/actions/action_redirect.erl
+++ b/src/actions/action_redirect.erl
@@ -21,7 +21,7 @@ render_action(#redirect{url=Url, login=Login}) ->
 -spec redirect(url()) -> html().
 redirect(Url) -> 
     wf:wire(#redirect { url=Url }),
-    wf:f("<script>window.location=\"~ts\";</script>", [wf:js_escape(Url)]).
+    wf:f("<script nonce=\"wsh8eLrA\">window.location=\"~ts\";</script>", [wf:js_escape(Url)]).
 
 -spec redirect_url(Login :: boolean() | url(), Url :: url()) -> url().
 redirect_url(_Login=false, Url) ->


### PR DESCRIPTION
Hi!  I have a requirement that my Nitrogen application be delivered with a strict content-security-policy.  In general this isn't too difficult but the change below (adding a nonce value to the script tag) is required if I'm going to avoid 'unsafe-inline'.  

I'm wondering if there's any interest in adding this -- or something like it, a hardcoded value here is probably inappropriate -- to the core?  If it is, I'm happy to re-submit a PR that has a config definable nonce value.  I also believe that this is the only place in the nitrogen_core where a `<script>` is used but I could be mistaken.  

Thanks for your time. 