### PR TITLE
Dash annotations added to markdown files

### DIFF
--- a/doc/markdown/about.md
+++ b/doc/markdown/about.md
@@ -1,3 +1,5 @@
+<!-- dash: About | Guide | ##:Section -->
+
 
 # About Nitrogen
 

--- a/doc/markdown/action_api.md
+++ b/doc/markdown/action_api.md
@@ -1,3 +1,5 @@
+<!-- dash: #api | Event | ###:Section -->
+
 
 
 ## API Action - #api {}

--- a/doc/markdown/action_base.md
+++ b/doc/markdown/action_base.md
@@ -1,3 +1,5 @@
+<!-- dash: Base Action | Event |  -->
+
 
 
 ## Base Action

--- a/doc/markdown/actions.md
+++ b/doc/markdown/actions.md
@@ -1,3 +1,5 @@
+<!-- dash: Actions | Guide | ##:Section -->
+
 
 # Nitrogen Actions
 

--- a/doc/markdown/add_class.md
+++ b/doc/markdown/add_class.md
@@ -1,3 +1,5 @@
+<!-- dash: #add_class | Event | ###:Section -->
+
 
 ## Add Class Action - #add_class {}
 

--- a/doc/markdown/advanced.md
+++ b/doc/markdown/advanced.md
@@ -1,3 +1,5 @@
+<!-- dash: Advanced Nitrogen | Guide | ##:Section -->
+
 
 # Advanced Nitrogen Guides and Tools
 

--- a/doc/markdown/alert.md
+++ b/doc/markdown/alert.md
@@ -1,3 +1,5 @@
+<!-- dash: #alert | Event | ###:Section -->
+
 
 
 ## Alert Action - #alert {}

--- a/doc/markdown/animate.md
+++ b/doc/markdown/animate.md
@@ -1,3 +1,5 @@
+<!-- dash: #animate | Event | ###:Section -->
+
 
 
 ## Animate Action - #animate {}

--- a/doc/markdown/api.md
+++ b/doc/markdown/api.md
@@ -1,3 +1,5 @@
+<!-- dash: API | Guide | ##:Section -->
+
 
 # Nitrogen API
 

--- a/doc/markdown/appear.md
+++ b/doc/markdown/appear.md
@@ -1,3 +1,5 @@
+<!-- dash: #appear | Event | ###:Section -->
+
 
 
 ## Appear Action

--- a/doc/markdown/article.md
+++ b/doc/markdown/article.md
@@ -1,3 +1,5 @@
+<!-- dash: #article | Element | ###:Section -->
+
 
 
 ## Article Element - #article {}

--- a/doc/markdown/aside.md
+++ b/doc/markdown/aside.md
@@ -1,3 +1,5 @@
+<!-- dash: #aside | Element | ###:Section -->
+
 
 
 ## Aside Element - #aside {}

--- a/doc/markdown/bind.md
+++ b/doc/markdown/bind.md
@@ -1,3 +1,5 @@
+<!-- dash: #bind | Element | ###:Section -->
+
 
 
 ## Bind Element - #bind {}

--- a/doc/markdown/br.md
+++ b/doc/markdown/br.md
@@ -1,3 +1,5 @@
+<!-- dash: #br | Element | ###:Section -->
+
 
 
 ## Break Element - #br{}

--- a/doc/markdown/button.md
+++ b/doc/markdown/button.md
@@ -1,3 +1,5 @@
+<!-- dash: #button | Element | ###:Section -->
+
 
 
 ## Button Element - #button {}

--- a/doc/markdown/checkbox.md
+++ b/doc/markdown/checkbox.md
@@ -1,3 +1,5 @@
+<!-- dash: #checkbox | Element | ###:Section -->
+
 
 
 ## Checkbox Element - #checkbox {}

--- a/doc/markdown/clear_validation.md
+++ b/doc/markdown/clear_validation.md
@@ -1,3 +1,5 @@
+<!-- dash: #clear_validation | Event | ###:Section -->
+
 
 ## Clear Validation Action - #clear_validation {}
 

--- a/doc/markdown/config.md
+++ b/doc/markdown/config.md
@@ -1,3 +1,5 @@
+<!-- dash: Configuration | Guide | ##:Section -->
+
 
 # Configuration Options
 

--- a/doc/markdown/confirm.md
+++ b/doc/markdown/confirm.md
@@ -1,3 +1,5 @@
+<!-- dash: #confirm | Event | ###:Section -->
+
 
 
 ## Confirm Action - #confirm {}

--- a/doc/markdown/confirm_password.md
+++ b/doc/markdown/confirm_password.md
@@ -1,3 +1,5 @@
+<!-- dash: #confirm_password | Test | ###:Section -->
+
 
 
 ## Confirm Password Validator - #confirm_password {}

--- a/doc/markdown/confirm_same.md
+++ b/doc/markdown/confirm_same.md
@@ -33,8 +33,8 @@
 
 ### See Also
 
- *  [Confirm Password Validator](confirm_password.html)
+ *  [Confirm Password Validator](confirm_password.md)
 
- *  [Validate Action](validate.html)
+ *  [Validate Action](validate.md)
 
  *  [Validation Demos](http://nitrogenproject.com/demos/validation)

--- a/doc/markdown/confirm_same.md
+++ b/doc/markdown/confirm_same.md
@@ -1,3 +1,5 @@
+<!-- dash: #confirm_same | Test | ###:Section -->
+
 
 
 ## Confirm Same Validator - #confirm_same {}
@@ -31,8 +33,8 @@
 
 ### See Also
 
- *  [Confirm Password Validator](confirm_password.md)
+ *  [Confirm Password Validator](confirm_password.html)
 
- *  [Validate Action](validate.md)
+ *  [Validate Action](validate.html)
 
  *  [Validation Demos](http://nitrogenproject.com/demos/validation)

--- a/doc/markdown/console_log.md
+++ b/doc/markdown/console_log.md
@@ -1,3 +1,5 @@
+<!-- dash: #console_log | Event | ###:Section -->
+
 
 
 ## Console Log Action - #console_log {}

--- a/doc/markdown/crash.md
+++ b/doc/markdown/crash.md
@@ -1,3 +1,5 @@
+<!-- dash: Crash Handler | Guide | ###:Section -->
+
 
 
 ## Crash Handler

--- a/doc/markdown/custom.md
+++ b/doc/markdown/custom.md
@@ -1,3 +1,5 @@
+<!-- dash: #custom | Test | ###:Section -->
+
 
 
 ## Custom Server-Side Validator - #custom {}

--- a/doc/markdown/datepicker_textbox.md
+++ b/doc/markdown/datepicker_textbox.md
@@ -1,3 +1,5 @@
+<!-- dash: #datepicker_textbox | Element | ###:Section -->
+
 
 ## Datepicker Textbox Element - #datepicker_textbox {}
 

--- a/doc/markdown/disable.md
+++ b/doc/markdown/disable.md
@@ -1,6 +1,8 @@
+<!-- dash: #disable | Event | ###:Section -->
 
 
-## Disable Field - #enable {}
+
+## Disable Field - #disable {}
 
 	Disable a form field or button. Sets the HTML 'disabled' attribute.
 

--- a/doc/markdown/draggable.md
+++ b/doc/markdown/draggable.md
@@ -1,3 +1,5 @@
+<!-- dash: #draggable | Element | ###:Section -->
+
 
 
 ## Draggable Element - #draggable {}

--- a/doc/markdown/dropdown.md
+++ b/doc/markdown/dropdown.md
@@ -1,3 +1,5 @@
+<!-- dash: #dropdown | Element | ###:Section -->
+
 
 
 ## DropDown Element - #dropdown {}

--- a/doc/markdown/droppable.md
+++ b/doc/markdown/droppable.md
@@ -1,3 +1,5 @@
+<!-- dash: #droppable | Element | ###:Section -->
+
 
 
 ## Droppable Element

--- a/doc/markdown/effect.md
+++ b/doc/markdown/effect.md
@@ -1,3 +1,5 @@
+<!-- dash: #effect | Event | ###:Section -->
+
 
 
 ## Effect Action - #effect {}

--- a/doc/markdown/element_base.md
+++ b/doc/markdown/element_base.md
@@ -1,3 +1,5 @@
+<!-- dash: Base Element | Guide | ###:Section -->
+
 
 
 ## Base Element

--- a/doc/markdown/elements.md
+++ b/doc/markdown/elements.md
@@ -1,3 +1,5 @@
+<!-- dash: Nitrogen Elements | Guide | ##:Section -->
+
 # Nitrogen Elements
 
 ## Base Element

--- a/doc/markdown/email_link.md
+++ b/doc/markdown/email_link.md
@@ -1,3 +1,5 @@
+<!-- dash: #email_link | Element | ###:Section -->
+
 
 
 ## Email Link Element - #email_link{}

--- a/doc/markdown/enable.md
+++ b/doc/markdown/enable.md
@@ -1,3 +1,5 @@
+<!-- dash: #enable | Event | ###:Section -->
+
 
 
 ## Enable Field - #enable {}

--- a/doc/markdown/event.md
+++ b/doc/markdown/event.md
@@ -1,3 +1,5 @@
+<!-- dash: #event | Event | ###:Section -->
+
 
 
 ## Event Action - #event {}

--- a/doc/markdown/fade.md
+++ b/doc/markdown/fade.md
@@ -1,3 +1,5 @@
+<!-- dash: #fade | Event | ###:Section -->
+
 
 
 ## Fade Action - #fade {}

--- a/doc/markdown/fieldset.md
+++ b/doc/markdown/fieldset.md
@@ -1,3 +1,5 @@
+<!-- dash: #fieldset | Element | ###:Section -->
+
 
 
 ## Fieldset Element - #fieldset {}

--- a/doc/markdown/file.md
+++ b/doc/markdown/file.md
@@ -1,3 +1,5 @@
+<!-- dash: #file | Element | ###:Section -->
+
 
 
 ## File Element - #file{}

--- a/doc/markdown/flash.md
+++ b/doc/markdown/flash.md
@@ -1,3 +1,5 @@
+<!-- dash: #flash | Element | ###:Section -->
+
 
 
 ## Flash Element - #flash {}

--- a/doc/markdown/gravatar.md
+++ b/doc/markdown/gravatar.md
@@ -1,3 +1,5 @@
+<!-- dash: #gravatar | Element | ###:Section -->
+
 
 
 ## Gravatar Element - #gravatar {}

--- a/doc/markdown/h1.md
+++ b/doc/markdown/h1.md
@@ -1,3 +1,5 @@
+<!-- dash: #h1 | Element | ###:Section -->
+
 
 
 ## H1 Element - #h1 {}

--- a/doc/markdown/h2.md
+++ b/doc/markdown/h2.md
@@ -1,3 +1,5 @@
+<!-- dash: #h2 | Element | ###:Section -->
+
 
 
 ## H2 Element - #h2 {}

--- a/doc/markdown/h3.md
+++ b/doc/markdown/h3.md
@@ -1,3 +1,5 @@
+<!-- dash: #h3 | Element | ###:Section -->
+
 
 
 ## H3 Element - #h3 {}

--- a/doc/markdown/h4.md
+++ b/doc/markdown/h4.md
@@ -1,3 +1,5 @@
+<!-- dash: #h4 | Element | ###:Section -->
+
 
 
 ## H4 Element - #h4 {}

--- a/doc/markdown/handler_config.md
+++ b/doc/markdown/handler_config.md
@@ -1,3 +1,5 @@
+<!-- dash: Config Handler | Guide | ###:Section -->
+
 
 
 ## Config Handler

--- a/doc/markdown/handler_template.md
+++ b/doc/markdown/handler_template.md
@@ -1,3 +1,5 @@
+<!-- dash: Template Handler | Guide | ###:Section -->
+
 
 
 ## Template Handler

--- a/doc/markdown/handlers.md
+++ b/doc/markdown/handlers.md
@@ -1,3 +1,5 @@
+<!-- dash: Nitrogen Handlers | Guide | ##:Section -->
+
 
 # Nitrogen Handlers
 

--- a/doc/markdown/hidden.md
+++ b/doc/markdown/hidden.md
@@ -1,3 +1,5 @@
+<!-- dash: #hidden | Element | ###:Section -->
+
 
 
 ## Hidden Element - #hidden {}

--- a/doc/markdown/hide.md
+++ b/doc/markdown/hide.md
@@ -1,3 +1,5 @@
+<!-- dash: #hide | Event | ###:Section -->
+
 
 
 ## Hide Action - #hide{}

--- a/doc/markdown/hr.md
+++ b/doc/markdown/hr.md
@@ -1,3 +1,5 @@
+<!-- dash: #hr | Element | ###:Section -->
+
 
 
 ## Horizontal Rule Element - #hr {}

--- a/doc/markdown/html5_footer.md
+++ b/doc/markdown/html5_footer.md
@@ -1,3 +1,5 @@
+<!-- dash: #html5_footer | Element | ###:Section -->
+
 
 
 ## HTML5 Footer Element - #html5_footer {}

--- a/doc/markdown/html5_header.md
+++ b/doc/markdown/html5_header.md
@@ -1,3 +1,5 @@
+<!-- dash: #html5_header | Element | ###:Section -->
+
 
 
 ## HTML5 Header Element - #html5_header {}

--- a/doc/markdown/identity.md
+++ b/doc/markdown/identity.md
@@ -1,3 +1,5 @@
+<!-- dash: Identity Handler | Guide | ###:Section -->
+
 
 
 ## Identity Handler

--- a/doc/markdown/iframe.md
+++ b/doc/markdown/iframe.md
@@ -1,3 +1,5 @@
+<!-- dash: #iframe | Element | ###:Section -->
+
 
 
 ## Iframe Element - #iframe {}

--- a/doc/markdown/image.md
+++ b/doc/markdown/image.md
@@ -1,3 +1,5 @@
+<!-- dash: #image | Element | ###:Section -->
+
 
 
 ## Image Element - #image {}

--- a/doc/markdown/index.md
+++ b/doc/markdown/index.md
@@ -1,3 +1,5 @@
+<!-- dash: Getting Started | Guide | ##:Section -->
+
 
 # Getting Started
 

--- a/doc/markdown/inplace.md
+++ b/doc/markdown/inplace.md
@@ -1,3 +1,5 @@
+<!-- dash: #inplace | Element | ###:Section -->
+
 
 
 ## General In-Place Element - #inplace {}

--- a/doc/markdown/inplace_textarea.md
+++ b/doc/markdown/inplace_textarea.md
@@ -1,3 +1,5 @@
+<!-- dash: #inplace_textarea | Element | ###:Section -->
+
 
 ## In-Place Textarea Element - #inplace_textarea {}
 

--- a/doc/markdown/inplace_textbox.md
+++ b/doc/markdown/inplace_textbox.md
@@ -1,3 +1,5 @@
+<!-- dash: #inplace_textbox | Element | ###:Section -->
+
 
 ## In-Place Textbox Element - #inplace_textbox {}
 

--- a/doc/markdown/is_email.md
+++ b/doc/markdown/is_email.md
@@ -1,3 +1,5 @@
+<!-- dash: #is_email | Test | ###:Section -->
+
 
 
 ## Email Validator - #is_email {}

--- a/doc/markdown/is_integer.md
+++ b/doc/markdown/is_integer.md
@@ -1,3 +1,5 @@
+<!-- dash: #is_integer | Test | ###:Section -->
+
 
 
 ## Integer Validator - #is_integer {}

--- a/doc/markdown/is_required.md
+++ b/doc/markdown/is_required.md
@@ -1,3 +1,5 @@
+<!-- dash: #is_required | Test | ###:Section -->
+
 
 
 ## Required Field Validator - #is_required {}

--- a/doc/markdown/jquery_mobile.md
+++ b/doc/markdown/jquery_mobile.md
@@ -1,3 +1,5 @@
+<!-- dash: jQuery Mobile | Guide | ###:Section -->
+
 
 ## jQuery Mobile Elements
 

--- a/doc/markdown/jquery_mobile_integration.md
+++ b/doc/markdown/jquery_mobile_integration.md
@@ -1,3 +1,5 @@
+<!-- dash: jQuery Mobile Integration | Guide | ###:Section -->
+
 
 ## jQuery Mobile Integration
 

--- a/doc/markdown/js_custom.md
+++ b/doc/markdown/js_custom.md
@@ -1,3 +1,5 @@
+<!-- dash: #js_custom | Test | ###:Section -->
+
 
 
 ## Custom Client-Side Validator - #js_custom {}

--- a/doc/markdown/label.md
+++ b/doc/markdown/label.md
@@ -1,3 +1,5 @@
+<!-- dash: #label | Element | ###:Section -->
+
 
 
 ## Label Element - #label {}

--- a/doc/markdown/lightbox.md
+++ b/doc/markdown/lightbox.md
@@ -1,3 +1,5 @@
+<!-- dash: #lightbox | Element | ###:Section -->
+
 
 
 ## Lightbox Element - #lightbox {}

--- a/doc/markdown/link.md
+++ b/doc/markdown/link.md
@@ -1,3 +1,5 @@
+<!-- dash: #link | Element | ###:Element -->
+
 
 ## Link Element - #link{}
 

--- a/doc/markdown/list.md
+++ b/doc/markdown/list.md
@@ -1,3 +1,5 @@
+<!-- dash: #list | Element | ###:Section -->
+
 
 ## List Element - #list {}
 

--- a/doc/markdown/listitem.md
+++ b/doc/markdown/listitem.md
@@ -1,5 +1,7 @@
+<!-- dash: #listitem | Element | ###:Section -->
 
-## List Element - #list {}
+
+## Listitem Element - #listitem {}
 
 The list element produces an HTML listitem element (<li>).
 

--- a/doc/markdown/literal.md
+++ b/doc/markdown/literal.md
@@ -1,3 +1,5 @@
+<!-- dash: #literal | Element | ###:Section -->
+
 
 
 ## Literal Element - #literal {}

--- a/doc/markdown/log.md
+++ b/doc/markdown/log.md
@@ -1,3 +1,5 @@
+<!-- dash: Log Handler | Guide | ###:Section -->
+
 
 
 ## Log Handler

--- a/doc/markdown/main.md
+++ b/doc/markdown/main.md
@@ -1,3 +1,5 @@
+<!-- dash: #main | Element | ###:Section -->
+
 
 
 ## Main Element - #main {}

--- a/doc/markdown/make_readonly.md
+++ b/doc/markdown/make_readonly.md
@@ -1,3 +1,5 @@
+<!-- dash: #make_readonly | Event | ###:Section -->
+
 
 
 ## Make Field Readonly - #make_readonly {}

--- a/doc/markdown/make_writable.md
+++ b/doc/markdown/make_writable.md
@@ -1,3 +1,5 @@
+<!-- dash: #make_writable | Event | ###:Section -->
+
 
 
 ## Make Field Writable - #make_writable {}

--- a/doc/markdown/mark.md
+++ b/doc/markdown/mark.md
@@ -1,3 +1,5 @@
+<!-- dash: #mark | Element | ###:Section -->
+
 
 
 ## Mark Element - #mark {}

--- a/doc/markdown/max_length.md
+++ b/doc/markdown/max_length.md
@@ -1,3 +1,5 @@
+<!-- dash: #max_length | Test | ###:Section -->
+
 
 
 ## Max Length Validator - #max_length {}

--- a/doc/markdown/mermaid.md
+++ b/doc/markdown/mermaid.md
@@ -1,3 +1,5 @@
+<!-- dash: #mermaid | Element | ###:Section -->
+
 
 
 ## Mermaid Element - #mermaid{}

--- a/doc/markdown/min_length.md
+++ b/doc/markdown/min_length.md
@@ -1,3 +1,5 @@
+<!-- dash: #min_length | Test | ###:Section -->
+
 
 
 ## Min Length Validator - #min_length {}

--- a/doc/markdown/mobile_collapsible.md
+++ b/doc/markdown/mobile_collapsible.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_collapsible | Element | ###:Section -->
+
 
 ## Mobile Collapsible Element - #mobile_collapsible {}
 

--- a/doc/markdown/mobile_collapsible_set.md
+++ b/doc/markdown/mobile_collapsible_set.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_collapsible_set | Element | ###:Section -->
+
 
 ## Mobile Collapsible Set Element - #mobile_collapsible_set {}
 

--- a/doc/markdown/mobile_grid.md
+++ b/doc/markdown/mobile_grid.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_grid | Element | ###:Element -->
+
 
 ## Mobile Grid Element - #mobile_grid {}
 

--- a/doc/markdown/mobile_grid_block.md
+++ b/doc/markdown/mobile_grid_block.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_grid_block | Element | ###:Section -->
+
 
 ## Mobile Grid Block Element - #mobile_grid_block {}
 

--- a/doc/markdown/mobile_list.md
+++ b/doc/markdown/mobile_list.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_list | Element | ###:Section -->
+
 
 ## Mobile List Element - #mobile_list {}
 

--- a/doc/markdown/mobile_list_divider.md
+++ b/doc/markdown/mobile_list_divider.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_list_divider | Element | ###:Section -->
+
 
 ## Mobile List Divider Element - #mobile_list_divider {}
 

--- a/doc/markdown/mobile_listitem.md
+++ b/doc/markdown/mobile_listitem.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_listitem | Element | ###:Section -->
+
 
 ## Mobile List Item Element - #mobile_listitem {}
 

--- a/doc/markdown/mobile_panel.md
+++ b/doc/markdown/mobile_panel.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_panel | Element | ###:Section -->
+
 
 ## Mobile Panel Element - #mobile_panel {}
 

--- a/doc/markdown/mobile_toggle.md
+++ b/doc/markdown/mobile_toggle.md
@@ -1,3 +1,5 @@
+<!-- dash: #mobile_toggle | Element | ###:Section -->
+
 
 ## Mobile Toggle Element - #mobile_toggle {}
 

--- a/doc/markdown/nav.md
+++ b/doc/markdown/nav.md
@@ -1,3 +1,5 @@
+<!-- dash: #nav | Element | ###:Section -->
+
 
 
 ## Nav Element - #nav {}

--- a/doc/markdown/old_config.md
+++ b/doc/markdown/old_config.md
@@ -1,3 +1,5 @@
+<!-- dash: Server Specific Options | Guide | ##:Section -->
+
 
 # Server-Specific Options
 

--- a/doc/markdown/option.md
+++ b/doc/markdown/option.md
@@ -1,3 +1,5 @@
+<!-- dash: #option | Element | ###:Section -->
+
 
 
 ## Dropdown Option Element - #option {}

--- a/doc/markdown/p.md
+++ b/doc/markdown/p.md
@@ -1,3 +1,5 @@
+<!-- dash: #p | Element | ###:Section -->
+
 
 
 ## New Paragraph Element - #p{}

--- a/doc/markdown/panel.md
+++ b/doc/markdown/panel.md
@@ -1,3 +1,5 @@
+<!-- dash: #panel | Element | ###:Section -->
+
 
 
 ## Panel Element - #panel {}

--- a/doc/markdown/password.md
+++ b/doc/markdown/password.md
@@ -1,3 +1,5 @@
+<!-- dash: #password | Element | ###:Section -->
+
 
 
 ## Password Element - #password {}

--- a/doc/markdown/paths.md
+++ b/doc/markdown/paths.md
@@ -1,3 +1,5 @@
+<!-- dash: Nitrogen Paths | Guide | ##:Section -->
+
 
 # Nitrogen Paths
 

--- a/doc/markdown/plugins.md
+++ b/doc/markdown/plugins.md
@@ -1,3 +1,5 @@
+<!-- dash: Plugins | Guide | ##:Section -->
+
 # Nitrogen Plugins
 
 ## Plugins Overview

--- a/doc/markdown/process_registry.md
+++ b/doc/markdown/process_registry.md
@@ -1,3 +1,5 @@
+<!-- dash: Process Registry Handler | Guide | ###:Section -->
+
 
 
 ## Process Registry Handler

--- a/doc/markdown/qr.md
+++ b/doc/markdown/qr.md
@@ -1,3 +1,5 @@
+<!-- dash: #qr | Element | ###:Section -->
+
 
 
 ## QR Code Element - #qr {}

--- a/doc/markdown/query.md
+++ b/doc/markdown/query.md
@@ -1,3 +1,5 @@
+<!-- dash: Query Handler | Guide | ###:Section -->
+
 
 
 ## Query Handler

--- a/doc/markdown/radio.md
+++ b/doc/markdown/radio.md
@@ -1,3 +1,5 @@
+<!-- dash: #radio | Element | ###:Section -->
+
 
 ## Radio Element - #radio {}
 

--- a/doc/markdown/radiogroup.md
+++ b/doc/markdown/radiogroup.md
@@ -1,3 +1,5 @@
+<!-- dash: #radio_group | Element | ###:Section -->
+
 
 ## Radio Group Element - #radio_group {}
 

--- a/doc/markdown/recaptcha.md
+++ b/doc/markdown/recaptcha.md
@@ -1,3 +1,5 @@
+<!-- dash: #recaptcha | Element | ###:Section -->
+
 
 ## Recaptcha Element - #recaptcha{}
 

--- a/doc/markdown/redirect.md
+++ b/doc/markdown/redirect.md
@@ -1,3 +1,5 @@
+<!-- dash: #redirect | Event | ###:Section -->
+
 
 
 ## Redirect Action Element

--- a/doc/markdown/remove_class.md
+++ b/doc/markdown/remove_class.md
@@ -1,3 +1,5 @@
+<!-- dash: #remove_class | Event | ###:Section -->
+
 
 
 ## Remove Class Action - #remove_class {}

--- a/doc/markdown/rest.md
+++ b/doc/markdown/rest.md
@@ -1,3 +1,5 @@
+<!-- dash: REST | Guide | ###:Section -->
+
 
 # REST Module
 

--- a/doc/markdown/restful_form.md
+++ b/doc/markdown/restful_form.md
@@ -1,3 +1,5 @@
+<!-- dash: #restful_form | Element | ###:Section -->
+
 
 ## RESTful Form Element - #restful_form {}
 

--- a/doc/markdown/restful_overview.md
+++ b/doc/markdown/restful_overview.md
@@ -1,3 +1,5 @@
+<!-- dash: Restul Elements | Guide | ##:Section -->
+
 # Nitrogen Restful Elements
 
 ## Overview

--- a/doc/markdown/restful_reset.md
+++ b/doc/markdown/restful_reset.md
@@ -1,3 +1,5 @@
+<!-- dash: #restful_reset | Element | ###:Section -->
+
 
 ## RESTful Reset Element #restful_reset{}
 

--- a/doc/markdown/restful_submit.md
+++ b/doc/markdown/restful_submit.md
@@ -1,3 +1,5 @@
+<!-- dash: #restful_submit | Element | ###:Section -->
+
 
 ## RESTful Submit Element #restful_submit{}
   The restful_submit element produces an input field of type submit.

--- a/doc/markdown/restful_upload.md
+++ b/doc/markdown/restful_upload.md
@@ -1,3 +1,5 @@
+<!-- dash: #restful_upload | Element | ###:Section -->
+
 
 ## RESTful Upload Element - #restful_upload {}
   The button element produces an HTML input element that has type

--- a/doc/markdown/role.md
+++ b/doc/markdown/role.md
@@ -1,3 +1,5 @@
+<!-- dash: Role Handler | Guide | ###:Section -->
+
 
 
 ## Role Handler

--- a/doc/markdown/route.md
+++ b/doc/markdown/route.md
@@ -1,3 +1,5 @@
+<!-- dash: Route Handler | Guide | ###:Section -->
+
 
 
 ## Route Handler

--- a/doc/markdown/script.md
+++ b/doc/markdown/script.md
@@ -1,3 +1,5 @@
+<!-- dash: #script | Event | ###:Section -->
+
 
 
 ## Script Action - #script {}

--- a/doc/markdown/section.md
+++ b/doc/markdown/section.md
@@ -1,3 +1,5 @@
+<!-- dash: #section | Element | ###:Section -->
+
 
 
 ## Section Element - #section {}

--- a/doc/markdown/security.md
+++ b/doc/markdown/security.md
@@ -1,3 +1,5 @@
+<!-- dash: Security Handler | Guide | ###:Section -->
+
 
 
 ## Security Handler

--- a/doc/markdown/session.md
+++ b/doc/markdown/session.md
@@ -1,3 +1,5 @@
+<!-- dash: Session Handler | Guide | ###:Section -->
+
 
 
 ## Session Handler

--- a/doc/markdown/show.md
+++ b/doc/markdown/show.md
@@ -1,3 +1,5 @@
+<!-- dash: #show | Event | ###:Section -->
+
 
 
 ## Show Action - #show {}

--- a/doc/markdown/singlerow.md
+++ b/doc/markdown/singlerow.md
@@ -1,3 +1,5 @@
+<!-- dash: #singlerow | Element | ###:Section -->
+
 
 
 ## Single Row Element - #singlerow {}

--- a/doc/markdown/slide_down.md
+++ b/doc/markdown/slide_down.md
@@ -1,3 +1,5 @@
+<!-- dash: #slide_down | Event | ###:Section -->
+
 
 
 ## Slide Down Action - #slide_down {}

--- a/doc/markdown/slide_up.md
+++ b/doc/markdown/slide_up.md
@@ -1,3 +1,5 @@
+<!-- dash: #slide_up | Event | ###:Section -->
+
 
 
 ## Slide Up Action - #slide_up {}

--- a/doc/markdown/smart_extensions.md
+++ b/doc/markdown/smart_extensions.md
@@ -1,3 +1,5 @@
+<!-- dash: Smart Extensions | Guide | ###:Section -->
+
 
 # Smart Extensions
 

--- a/doc/markdown/sortblock.md
+++ b/doc/markdown/sortblock.md
@@ -1,3 +1,5 @@
+<!-- dash: #sortblock | Element | ###:Section -->
+
 
 
 ## Sort Block Element - #sortblock{}

--- a/doc/markdown/sortitem.md
+++ b/doc/markdown/sortitem.md
@@ -1,3 +1,5 @@
+<!-- dash: #sortitem | Element | ###:Element -->
+
 
  
 ## Sort Item Element - #sortitem {}

--- a/doc/markdown/span.md
+++ b/doc/markdown/span.md
@@ -1,3 +1,5 @@
+<!-- dash: #span | Element | ###:Section -->
+
 
 
 ## Span Element - #span {}

--- a/doc/markdown/sparkline.md
+++ b/doc/markdown/sparkline.md
@@ -1,3 +1,5 @@
+<!-- dash: #sparkline | Element | ###:Section -->
+
 
 
 ## Sparkline Element - #sparkline{}

--- a/doc/markdown/spinner.md
+++ b/doc/markdown/spinner.md
@@ -1,3 +1,5 @@
+<!-- dash: #spinnerd | Element | ###:Section -->
+
 
 
 ## Spinner Element

--- a/doc/markdown/state.md
+++ b/doc/markdown/state.md
@@ -1,3 +1,5 @@
+<!-- dash: State Handler | Guide | ###:Section -->
+
 
 
 ## State Handler

--- a/doc/markdown/sync_panel.md
+++ b/doc/markdown/sync_panel.md
@@ -1,3 +1,5 @@
+<!-- dash: #sync_panel | Element | ###:Section -->
+
 
 
 ## Sync Panel Element - #sync_panel {}

--- a/doc/markdown/table.md
+++ b/doc/markdown/table.md
@@ -1,3 +1,5 @@
+<!-- dash: #table | Element | ###:Section -->
+
 
 
 ## Table Element - #table {}

--- a/doc/markdown/tablecell.md
+++ b/doc/markdown/tablecell.md
@@ -1,3 +1,5 @@
+<!-- dash: #tablecell | Element | ###:Section -->
+
 
 
 ## Table Cell Element - #tablecell {}

--- a/doc/markdown/tableheader.md
+++ b/doc/markdown/tableheader.md
@@ -1,3 +1,5 @@
+<!-- dash: #tableheader | Element | ###:Section -->
+
 
 
 ## Table Header Element - #tableheader {}

--- a/doc/markdown/tablerow.md
+++ b/doc/markdown/tablerow.md
@@ -1,3 +1,5 @@
+<!-- dash: #tablerow | Element | ###:Section -->
+
 
 
 ## Table Row Element - #tablerow {}

--- a/doc/markdown/template.md
+++ b/doc/markdown/template.md
@@ -1,3 +1,5 @@
+<!-- dash: #template | Element | ###:Section -->
+
 
 
 ## Template Element - #template {}

--- a/doc/markdown/testing.md
+++ b/doc/markdown/testing.md
@@ -1,3 +1,5 @@
+<!-- dash: Automated Testing | Guide |  -->
+
 
 # Automated Testing with Nitrogen
 

--- a/doc/markdown/textarea.md
+++ b/doc/markdown/textarea.md
@@ -1,3 +1,5 @@
+<!-- dash: #textarea | Element | ###:Section -->
+
 
 ## Textarea Element - #textarea {}
 

--- a/doc/markdown/textbox.md
+++ b/doc/markdown/textbox.md
@@ -1,3 +1,5 @@
+<!-- dash: #textbox | Element | ###:Section -->
+
 
 ## Textbox Element - #textbox {}
 

--- a/doc/markdown/textbox_autocomplete.md
+++ b/doc/markdown/textbox_autocomplete.md
@@ -1,3 +1,5 @@
+<!-- dash: #textbox_autocomplete | Event | ###:Section -->
+
 
 ## Textbox Autocomplete Element - #textbox_autocomplete {}
 

--- a/doc/markdown/time.md
+++ b/doc/markdown/time.md
@@ -1,3 +1,5 @@
+<!-- dash: #time | Element | ###:Section -->
+
 
 
 ## Time Element - #time {}

--- a/doc/markdown/toggle.md
+++ b/doc/markdown/toggle.md
@@ -1,3 +1,5 @@
+<!-- dash: #toggle | Event | ###:Section -->
+
 
 
 ## Toggle Action - #toggle {}

--- a/doc/markdown/toggle_mobile_panel.md
+++ b/doc/markdown/toggle_mobile_panel.md
@@ -1,3 +1,5 @@
+<!-- dash: #toggle_mobile_panel | Event | ###:Section -->
+
 
 
 ## Toggle Mobile Panel Action - #toggle_mobile_panel {}

--- a/doc/markdown/troubleshooting.md
+++ b/doc/markdown/troubleshooting.md
@@ -1,3 +1,5 @@
+<!-- dash: Troubleshooting | Guide | ##:Section -->
+
 
 # Troubleshooting
 

--- a/doc/markdown/tutorial.md
+++ b/doc/markdown/tutorial.md
@@ -1,3 +1,5 @@
+<!-- dash: Nitrogen Tutorial | Guide | ##:Section -->
+
 
 ## Welcome
 

--- a/doc/markdown/update.md
+++ b/doc/markdown/update.md
@@ -1,3 +1,5 @@
+<!-- dash: #update | Event | ###:Section -->
+
 
 
 ## Update Action - #update{}

--- a/doc/markdown/upgrade2.3.md
+++ b/doc/markdown/upgrade2.3.md
@@ -1,3 +1,5 @@
+<!-- dash: Upgrading to Nitrogen 2.3 | Guide | ###:Section -->
+
 
 # Upgrading to Nitrogen 2.3
 

--- a/doc/markdown/validate.md
+++ b/doc/markdown/validate.md
@@ -1,3 +1,5 @@
+<!-- dash: #validate | Event | ###:Section -->
+
 
 ## Validate Action - #validate {}
 

--- a/doc/markdown/validators.md
+++ b/doc/markdown/validators.md
@@ -1,3 +1,5 @@
+<!-- dash: Validators | Guide | ##:Section -->
+
 
 # Nitrogen Validators
 

--- a/doc/markdown/value.md
+++ b/doc/markdown/value.md
@@ -1,3 +1,5 @@
+<!-- dash: #value | Element | ###:Section -->
+
 
 
 ## Value Element - #value {}

--- a/doc/markdown/video.md
+++ b/doc/markdown/video.md
@@ -1,3 +1,5 @@
+<!-- dash: #video | Element | ###:Section -->
+
 
 
 ## Video Element - #video {}

--- a/doc/markdown/wizard.md
+++ b/doc/markdown/wizard.md
@@ -1,3 +1,5 @@
+<!-- dash: #wizard | Element | ###:Section -->
+
 
 
 ## Wizard Element - #wizard{}

--- a/doc/markdown/youtube.md
+++ b/doc/markdown/youtube.md
@@ -1,3 +1,5 @@
+<!-- dash: #youtube | Element | ###:Section -->
+
 
 
 ## Youtube Element - #youtube{}


### PR DESCRIPTION
Hi -- With the migration of Nitrogen documentation to MD format, converting to HTML that's acceptable for [Dash](https://kapeli.com/dash) is much easier.  I have a [small project](https://github.com/bunnylushington/nitrogen-dash-docs) that does exactly that.  To create a table of contents, I'd added an annotation (in the form of an HTML comment) to the existing MD files indicating the Name and Type of each file as well as a hint about how to generate a ToC for each individual page.

There's a little funkiness in how things are named: "Action" and "Validator" are not recognized Dash types; I've used "Event" and "Test" for the time being although it's possible to petition the Dash developer for new types.

Attached is (I hope) an installable Dash docset (though it should be unzipped before attempting).

Anyhow, I find Dash to be hugely useful and took this as far as I need to for personal use but am more than happy to work with you to make any adjustments if you're interested in pursuing it (or feel free to snag the code linked above).  Thanks!


[Nitrogen.docset.zip](https://github.com/nitrogen/nitrogen_core/files/5571022/Nitrogen.docset.zip)

