### PR TITLE
documentation: query handler example code

### DIFF
--- a/doc/markdown/query.md
+++ b/doc/markdown/query.md
@@ -67,9 +67,9 @@ Here is the complete text of the default_query_handler:
 init(_Config, _State) ->
     % Get query params and post params
     % from the request bridge...
-    RequestBridge = wf_context:request_bridge(),
-    QueryParams = RequestBridge:query_params(),
-    PostParams = RequestBridge:post_params(),
+    Bridge = wf_context:request_bridge(),
+    QueryParams = sbw:query_params(Bridge),
+    PostParams = sbw:post_params(Bridge),
 
     % Load into state...
     Params = QueryParams ++ PostParams,


### PR DESCRIPTION
It appears there's been a simple_bridge API change.  This PR updates the example query handler documentation to reflect that change.  

It might be noted that this was the one issue of only two issues I had updating a well customized Nitrogen project: built from source using rebar3, custom handlers, self-rolled elements, and so on.  That's pretty damn good.