### PR TITLE
"inline" template content

### DIFF
--- a/doc/markdown/template.md
+++ b/doc/markdown/template.md
@@ -9,7 +9,7 @@
   while using a special callout syntax to call back to your page or any Erlang module.
 
   To specify a callout in the html template file, use the form:
-  
+
 ```erlang
   [[[Module:Function(Args)]]]
 
@@ -26,7 +26,7 @@
   It's also possible to specify alias module references to other modules. For
   example, the default module alias is actually `[{page, wf:page_module()}]`,
   which basically means "If you encounter page:function(Args), replace `page`
-  with the current page's module." 
+  with the current page's module."
 
 ### Usage
 
@@ -43,6 +43,9 @@
 * `file` (String) - Path to an html template file, relative
    to the directory from which Erlang was started.
 
+* `text` (string or binary) - If present, Nitrogen will use the value
+  as the template text, ignoring tthe `file` value (if present).
+
 * `from_type` (atom or string) - What is the file type you're loading (default: `html`)
 
 * `to_type` (atom or string) - What is the format we should convert to (default: `html`)
@@ -55,12 +58,10 @@
    variable bindings to be used for arguments specified in the
    template. Example: `[{'MyArg1', "Hello"}, {'MyArg2', "World"}]`
 
-* `module_aliases` (proplist of `{alias, actual_module}` pairs) - When 
+* `module_aliases` (proplist of `{alias, actual_module}` pairs) - When
    `alias` is encountered as the module of a `Module:Function(Args)` call,
    replace `alias` with `actual_module`.
 
 ### See Also
 
  *  [base element](./element_base.md)
-
- 

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -195,6 +195,7 @@
 -record(elementbase, {?ELEMENT_BASE(undefined)}).
 -record(template, {?ELEMENT_BASE(element_template),
        file                     :: string(),
+       text=[]                  :: string() | binary(),
        to_type=html             :: string() | atom() | binary(),
        from_type=html           :: string() | atom() | binary(),
        options=[]               :: [{atom(), string() | atom()}],


### PR DESCRIPTION
## Summary

Update the template element to allow for inline templates, bypassing the filesystem completely.

## Rationale

Although templates are usually static files, there are use cases where it is appropriate to render templates that have been dynamically generated (for instance, with ErlyDTL) or are trivial enough to warrant keeping them close to the source.  

A specific (and non-contrived!) example: I'll often use [ErlyDTL](https://github.com/erlydtl/erlydtl) to iterate over data to generate [Bootstrap cards](https://getbootstrap.com/docs/4.5/components/card/).  (This is, of course, possible in Nitrogen but it's far easier to read the HTML than long lists of nested `#panel` records.)  If I want to add, say, `#button` elements to these DTL generated pages with the callout `[[[page:button(...)]]]` it's easiest to pretend the output of ErlyDTL's rendering is a `#template` and let nitrogen_core do the lifting rather than essentially duplicating the code to re-implement callouts.


## Demonstration

```erlang
-module(index).
-include_lib("nitrogen_core/include/wf.hrl").
-export([main/0, title/0, body/0]).

main() ->
  case wf:path_info() of
    "text"    -> #template{ text=fake_template() };
    "textbin" -> #template{ text=wf:to_binary(fake_template()) };
    "nocalls" -> #template{ text=fake_template(), callouts=false };
    _         -> #template{ file=nxo:template("index.html") }
  end.

fake_template() ->
  "The title of this page is [[[page:title()]]].".

title() -> "Welcome to NXO".

body() -> "".
```