### PR TITLE
integrated CSP header/nonce generation

### DIFF
--- a/doc/markdown/advanced.md
+++ b/doc/markdown/advanced.md
@@ -33,3 +33,6 @@
 
  *  [Deploying Nitrogen on Heroku](https://web.archive.org/web/20170429000130/http://cstar.io/2014/07/02/nitrogen-on-heroku.html) (external) :: A step-by-step
     guide to making your Nitrogen app Heroku-ready.
+
+ *  [Content Security Policy](csp.md) :: Nitrogen provides a mechanism
+    to generate a Content-Security-Policy header from a configuration.

--- a/doc/markdown/api.md
+++ b/doc/markdown/api.md
@@ -20,7 +20,7 @@
 
    Update a form element (textbox, dropdown, checkbox, etc) to set text value
    of TargetID. Can also be used to set the `src` attribute of an image tag.
-   
+
 * `wf:enable(Target) -> ok`
 * `wf:enable(Priority, Target) -> ok`
 
@@ -45,13 +45,13 @@
 * `wf:remove(Priority, TargetID) -> ok`
 
    Remove TargetID from the DOM.
-   
+
 * `wf:insert_top(TargetID, Elements) -> ok`
 * `wf:insert_top(Priority, TargetID, Elements) -> ok`
 
    Insert Nitrogen Elements at the top of TargetID (within the contents of
    TargetID), shifting the existing contents downward.
-   
+
 * `wf:insert_bottom(TargetID, Elements) -> ok`
 * `wf:insert_bottom(Priority, TargetID, Elements) -> ok`
 
@@ -63,7 +63,7 @@
 
    Insert Nitrogen Elements before TargetID in the DOM, shifting the existing
    contents downward.
-   
+
 * `wf:insert_after(TargetID, Elements) -> ok`
 * `wf:insert_after(Priority, TargetID, Elements) -> ok`
 
@@ -83,21 +83,21 @@
 
    Note, if `Format` is a binary, the return type will be a binary, and if
    `Format` is a string, the return type will be a string.
-   
+
 * `wf:coalesce([List]) -> Item`
 
    Return the first element in the list that is not 'undefined'.
-   
+
 * `wf:is_string(Term) -> Bool`
 
    Return true if the Term is an Erlang string. That is, a flat list
    of integers.
-   
+
 * `wf:to_list(Term) -> List`
 
    Convert the supplied term to a flat list, if possible. Useful for
    turning Integers, Atoms, Binaries into Strings.
-   
+
 * `wf:to_atom(Term) -> Atom`
 
    Convert the supplied term into an Atom, if possible. Useful for
@@ -139,7 +139,7 @@
    Encode a PropList (a list of `{Key, Value}` tuples) into a URL-encoded query string (returned as an IOList).
 
 * `wf:hex_encode(String) -> EncodedString.`
-  
+
    Hex-encode the supplied String.
 
 * `wf:hex_decode(String) -> DecodedString`
@@ -176,7 +176,7 @@
 ```
 
 ## Event Wiring
-   
+
 * `wf:wire(Actions) -> ok`
 
    Wire actions to the page. The Actions are applied against the entire page unless a
@@ -188,7 +188,7 @@
    wf:wire(#alert { text="Hello, World!" })
 
 ```
-   
+
 * `wf:wire(TargetID, Actions) -> ok`
 
    Wire actions to the page, targeted against supplied TargetID.
@@ -255,7 +255,7 @@
 
    Send the specified message to all comet function connected to the
    specified GlobalPool.
-   
+
 * `wf:flush() -> ok`
 
    Normally, the results of a comet function are sent to the browser when the function exits.
@@ -284,7 +284,7 @@
 
    Spawn the provided function (arity 0) and tell the browser to poll for the results.
    See [continuations example](http://nitrogenproject.com/demos/continuations) for usage.
-   
+
 * `wf:continue(Tag, Function, Interval) -> ok`
 
    Spawn the provided function (arity 0) and tell the browser to poll for the results at the specified interval.
@@ -296,7 +296,7 @@
   delivered by `wf:send/2` and `wf:send_global/2`. These messages are:
 
 * `'INIT'`
-	
+
   The init message is sent to the first process in a comet pool.
 
 * `{'JOIN', Pid}`
@@ -304,7 +304,7 @@
   This message is sent to already existing comets when a new process joins to the pool
 
 * `{'LEAVE', Pid}`
-	
+
   This message is triggered when certain comet process terminates and it is delivered to
   all other processes in the pool
 
@@ -315,7 +315,7 @@
 comet_function() ->
   process_flag(trap_exit, true),
   receive
-    {'EXIT', _, Message} -> 
+    {'EXIT', _, Message} ->
 		?PRINT(Message),
 		io:format("The user has left the page.~n")
   end.
@@ -326,7 +326,7 @@ comet_function() ->
 * `wf:redirect(URL) -> ok`
 
    Redirect to the provided `URL`.
-   
+
 * `wf:redirect_to_login(URL) -> ok`
 
   See Below.
@@ -360,25 +360,25 @@ comet_function() ->
 
    Retrieve the session value stored under a specific key. If not
    found, return the supplied default value.
-   
+
 * `wf:session(Key, Value) -> OldValue`
-   
+
    Store a session variable for the current user. Key and Value can be any Erlang term.
    For example, store a count: `wf:session(count, Count)`
 
    Returns the previous value associated with Key.
 
-   
+
 * `wf:clear_session() -> ok`
 
    Clear the current user's session.
-   
+
 * `wf:logout() -> ok`
 
    Clear session state, page state, identity, and roles.
 
 ## Page State
-   
+
 * `wf:state(Key) -> Value`
 
    Retrieve a page state value stored under the specified key. Page State is
@@ -389,19 +389,19 @@ comet_function() ->
 
    Retrieve a page state value stored under the specified key. If the
    value is not set, then return the supplied default value.
-   
+
 * `wf:state(Key, Value) -> ok`
 
    Store a page state variable for the current user. Page State is
    different from Session State in that Page State is scoped to a series
    of requests by one user to one Nitrogen Page.
-   
+
 * `wf:clear_state() -> ok`
 
    Clear a user's page state.
 
 ## Authentication and Authorization
-   
+
 * `wf:user() -> User or 'undefined'`
 
    Return the user value that was previously set by `wf:user(User)`
@@ -409,20 +409,20 @@ comet_function() ->
 * `wf:user(User) -> ok`
 
    Set the user for the current session.
-   
+
 * `wf:clear_user() -> ok`
 
    Same as `wf:user(undefined)`.
-   
+
 * `wf:role(Role) -> boolean`
 
    Check if the current user has a specified role.
-   
+
 * `wf:role(Role, IsInRole) -> ok`
 
    Set whether the current user is in a specified role. `IsInRole` should be a
    boolean (`true` or `false`)
-   
+
 * `wf:clear_roles() -> ok`
 
    Remove the user from all roles.
@@ -430,7 +430,7 @@ comet_function() ->
 ## Web Request and Response
 
 * `wf:in_request() -> boolean()`
-   
+
    Checks if the current running process is actually inside a Nitrogen request,
    that is to say, that it has a Nitrogen-initialized context.  Returns `true`
    if the current process is a Nitrogen request, and `false` otherwise.
@@ -486,7 +486,7 @@ Example:
 
    Get a list of query string and POST values for the provided
    key. (This acts like `wf:q(AtomKey)` in Nitrogen 1.0.)
-  
+
    **Mnemonic:** Think `qs` as "Query Plural"
 
 * `wf:mqs(ListOfAtomKeys) -> [ListOfStrings]`
@@ -525,8 +525,8 @@ Example:
 
 * `wf:request_body() -> String`
 
-   Return the complete text of the request body to the server. Note, this value 
-   will use the context of the current request. For example, the result of calling 
+   Return the complete text of the request body to the server. Note, this value
+   will use the context of the current request. For example, the result of calling
    this during the page's initial request will be different than calling it within
    a postback event.
 
@@ -560,11 +560,11 @@ Example:
 * `wf:status_code(IntegerCode) -> ok`
 
    Set the HTTP response code. Default is 200.
-   
+
 * `wf:content_type(ContentType) -> ok`
 
    Set the HTTP content type. Defaults is `"text/html"`. This can be
-   used to return text images or other files to the browser, rather than returning 
+   used to return text images or other files to the browser, rather than returning
    HTML.
 
 * `wf:download_as(Filename) -> ok`
@@ -601,7 +601,7 @@ Example:
    the module web_my_page is requsted with the path
    `"/web/my/page/some/extra/stuff` then `wf:path_info()` would return
    `"some/extra/stuff"`.
-   
+
 * `wf:page_module() -> Atom`
 
    Return the requested page module. Useful information to know when writing a
@@ -657,7 +657,7 @@ Example:
 
    Tell Nitrogen to set a cookie on the browser. Uses \"/\" for the Path, and Nitrogen's
    session timeout setting for the MinutesToLive value.
-   
+
 * `wf:cookie(Key, Value, Path, MinutesToLive) -> ok`
 
    Tell Nitrogen to set a cookie on the browser under the specified Path that is valid
@@ -665,21 +665,26 @@ Example:
 
 * `wf:delete_cookie(Key) -> ok`
 
-   Tell Nitrogen to set the cookie to expire immediately, effectively deleting it from 
+   Tell Nitrogen to set the cookie to expire immediately, effectively deleting it from
    the browser.  Is a shortcut for `wf:cookie(Key,"","/",0)`.
- 
+
+* `wf:script_nonce() -> String`
+
+    Get the value of the nonce in the current context.  See [Content
+    Security Policy](csp.md) for more information.
+
 ## HTTP Headers
-   
+
 * `wf:headers() -> [{AtomKey, StringValue}, ...]`
 
    Return a proplist of all HTTP headers.
-   
+
 * `wf:header(AtomKey) -> Value`
 
    Get the value of an HTTP header.
 
 * `wf:header_default(AtomKey, Default) -> Value.`
-  
+
    Get the value of an HTTP header, if it doesn't exist, return the default.
 
 * `wf:header(StringKey, HeaderValue) -> ok`
@@ -687,15 +692,15 @@ Example:
    Set an HTTP header during the next response.
 
 ## Serialization
-   
+
 * `wf:pickle(Term) -> PickledBinary`
 
    Serialize a term into a web-safe, checksummed, and AES-encrypted hex string.
-   
+
 * `wf:depickle(PickledBinary) -> Term`
 
    Turn a pickled binary back into the original term.
-   
+
 * `wf:depickle(PickledBinary, SecondsToLive) -> Term or 'undefined'`
 
    Turn a pickled binary back into the original term, checking to see
@@ -720,7 +725,7 @@ Example:
 * `wf:warning(Format, Args)`
 
    Log a warning message.
-  
+
 * `wf:error(String)`
 
    Log an error message.
@@ -736,12 +741,10 @@ Example:
 ## Configuration
 
 * `wf:config(Key) -> Term`
-   
+
    Get the Nitrogen configuration setting under the specified Key.
 
 * `wf:config_default(Key, DefaultValue) -> Term`
 
    Get the Nitrogen configuration setting under the specified Key. If
    not set, then return DefaultValue.
-
-  

--- a/doc/markdown/csp.md
+++ b/doc/markdown/csp.md
@@ -1,0 +1,92 @@
+<!-- dash: Content Security Policy | Guide | ##:Section -->
+
+# Content Security Policy
+
+## Overview
+
+[Content Security Policy](https://content-security-policy.com) (CSP)
+is an HTTP response header that helps reduce XSS risks by declaring
+which dynamic resources are allowed to load.  Nitrogen supports CSP in
+two ways:
+
+  * Producing an appropriate HTTP header from a configuration.
+
+  * Creating and exposing a nonce values for use in templates.
+
+## Content-Security-Policy Header
+
+If the configuration key `content_security_policy` is present in the
+config (specifically via `wf:config(content_security_policy)`) a
+header will be produced.  The format of the configuration is:
+
+``` erlang
+{nitrogen_core,
+  [{content_security_policy,
+    [
+      {default_src, [none]},
+      {script_src, [self, nonce, unsafe_eval]},
+      {style_src, [self, "*.fontawesome.com"]}
+    ]}
+  ]}.
+
+```
+
+Each key in the proplist represents a CSP domain (e.g., "default-src",
+"script-src", "style-src"); the value of each element is a list of
+permitted sources.
+
+Domains may either be atoms (as shown, with underscores instead of
+hyphens) or strings (retaining the hyphens documented in the CSP
+specification).
+
+Sources might be strings ("*.fontawesome.com") or atoms (self).
+Strings are left untouched by the CSP header constructor; atoms are
+translated into single-quoted strings.  The following atoms are
+available:
+
+  * none
+  * self
+  * data
+  * https
+  * unsafe_inline
+  * unsafe_eval
+  * strict_dynamic
+  * unsafe_hashes
+  * nonce
+
+If the `content_security_policy` key is missing, no CSP header will be
+generated.  (Although a nonce value will still be generated, see
+below.)
+
+## Nonce Values
+
+Each first_request generates a 12 character nonce value which becomes
+the `script_nonce` attribute of the `#context` record.  This value is
+made available via `wf:script_nonce/0` and is appropriate for use in
+templates, e.g.,
+
+``` html
+<script nonce="[[[wf:script_nonce()]]]">
+  [[[script]]]
+</script>
+```
+
+If a `content_security_policy` references `nonce` in its source list,
+the value created for the header is `"nonce-" ++ wf:script_nonce()`.
+
+## Note
+
+Details on how to configure an appropriate CSP ruleset is outside the
+scope of this document (and can be non-trivial).  Two Nitrogen
+specific hints:
+
+  * `script_src` will most likely require `unsafe_eval` due to the way
+    Nitrogen handles browser communication; and,
+
+  * `connect_src` will most likely require some specification for the
+    websocket.
+
+## References
+
+- [Mozilla Developer Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [content-security-policy.com](https://content-security-policy.com)

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -18,7 +18,7 @@
 
 -type nitrogen_element()    :: tuple().
 -type template_script_element() :: script | mobile_script.
--type body_element()        :: nitrogen_element() | binary() | string() | iolist() 
+-type body_element()        :: nitrogen_element() | binary() | string() | iolist()
                                 | template_script_element().
 -type body()                :: body_element() | [body_element()].
 -type action_element()      :: undefined | tuple() | string() | binary() | iolist().
@@ -30,8 +30,8 @@
 -type proplist()            :: [{term(), term()}].
 -type data_field_name()     :: atom() | text().
 -type data_field_value()    :: atom() | text().
--type data_fields()         :: [data_field_name() 
-                                | {data_field_name()} 
+-type data_fields()         :: [data_field_name()
+                                | {data_field_name()}
                                 | {data_field_name(),data_field_value()}].
 -type wire_priority()       :: eager | normal | defer.
 -type class()               :: string() | binary() | atom().
@@ -45,7 +45,7 @@
 -type mobile_theme()        :: string() | binary() | atom().
 -type comet_name()          :: term().
 -type comet_restart_msg()   :: term().
--type comet_function()      :: pid() | function() 
+-type comet_function()      :: pid() | function()
                                 | {comet_name(), function()}
                                 | {comet_name(), function(), comet_restart_msg()}.
 -type handler_config()      :: any().
@@ -106,7 +106,7 @@
     % Transient Information
     type                    :: context_type(),
     bridge                  :: undefined | simple_bridge:bridge(), %% will only be undefined when "not in a request"
-    anchor=undefined        :: id(), 
+    anchor=undefined        :: id(),
     data=[]                 :: context_data(),
     encoding=auto           :: encoding(),
     caching=false           :: boolean(),
@@ -115,7 +115,8 @@
     % and de-serialized on each request.
     page_context            :: undefined | #page_context{},
     event_context           :: undefined | #event_context{},
-    handler_list            :: undefined | list()
+    handler_list            :: undefined | list(),
+    script_nonce            :: undefined | string()
 }).
 
 %%% LOGGING %%%
@@ -159,7 +160,7 @@
                          WF_IF_VALUE==undefined;
                          WF_IF_VALUE==[] ->
                 IfFalse;
-            _ -> 
+            _ ->
                 IfTrue
         end
     end()).
@@ -180,7 +181,7 @@
         %% If we kept it as just `is_element`, that may be just fine, but then
         %% users would probably have to use dialyzer to debug the "is not an
         %% element" error
-        is_element=is_element   :: is_element | any(), 
+        is_element=is_element   :: is_element | any(),
         module=Module           :: atom(),
         id                      :: id(),
         anchor                  :: id(),
@@ -190,7 +191,7 @@
         style=""                :: text(),
         html_id=""              :: id(),
         title=""                :: undefined | text(),
-        data_fields=[]          :: data_fields()        
+        data_fields=[]          :: data_fields()
     ).
 
 -record(elementbase, {?ELEMENT_BASE(undefined)}).
@@ -296,7 +297,7 @@
         text=""                 :: text(),
         html_encode=true        :: html_encode()
     }).
--record(delay_body, {?ELEMENT_BASE(element_delay_body), 
+-record(delay_body, {?ELEMENT_BASE(element_delay_body),
         delegate                :: module(),
         tag=undefined           :: term(),
         placeholder             :: body(),
@@ -794,7 +795,7 @@
         width                   :: integer(),
         allowfullscreen=true    :: boolean()
     }).
-        
+
 %% HTML5 semantic elements
 -record(section, {?ELEMENT_BASE(element_section),
         body=""                 :: body(),

--- a/src/actions/action_redirect.erl
+++ b/src/actions/action_redirect.erl
@@ -19,9 +19,10 @@ render_action(#redirect{url=Url, login=Login}) ->
     wf:f("window.location=\"~ts\";", [wf:js_escape(RedirectUrl)]).
 
 -spec redirect(url()) -> html().
-redirect(Url) -> 
+redirect(Url) ->
     wf:wire(#redirect { url=Url }),
-    wf:f("<script>window.location=\"~ts\";</script>", [wf:js_escape(Url)]).
+    wf:f("<script>nonce=\"~s\" window.location=\"~ts\";</script>",
+         [wf_context:script_nonce(), wf:js_escape(Url)]).
 
 -spec redirect_url(Login :: boolean() | url(), Url :: url()) -> url().
 redirect_url(_Login=false, Url) ->
@@ -53,7 +54,7 @@ redirect_to_login(LoginUrl) ->
     redirect(login_redirect_url(LoginUrl)).
 
 -spec redirect_from_login(url()) -> html().
-redirect_from_login(DefaultUrl) ->	
+redirect_from_login(DefaultUrl) ->
     PickledUrl = wf:q(x),
     case wf:depickle(PickledUrl) of
         undefined -> redirect(DefaultUrl);

--- a/src/lib/wf_context.erl
+++ b/src/lib/wf_context.erl
@@ -56,7 +56,7 @@
 
         page_context/0,
         page_context/1,
-       
+
         entry_point/0,
         entry_point/1,
 
@@ -98,7 +98,13 @@
         make_handler/2,
 
         context/0,
-        context/1
+        context/1,
+
+        script_nonce/0,
+        script_nonce/1,
+
+        content_security_policy/0,
+        content_security_policy/1
     ]).
 
 -export([increment/1]).
@@ -236,6 +242,21 @@ encoding() ->
     Context = context(),
     Context#context.encoding.
 
+script_nonce() ->
+    Context = context(),
+    Context#context.script_nonce.
+
+script_nonce(Value) ->
+    Context = context(),
+    context(Context#context{ script_nonce=Value }).
+
+content_security_policy() ->
+  content_security_policy(wf_security_policy:generate()).
+
+content_security_policy(undefined) ->
+  ok;
+content_security_policy(Policy) ->
+  header("Content-Security-Policy", Policy).
 
 %%% TRANSIENT CONTEXT %%%
 
@@ -314,7 +335,7 @@ series_id(SeriesID) ->
     Page = page_context(),
     page_context(Page#page_context { series_id = SeriesID }).
 
-page_module() -> 
+page_module() ->
     Page = page_context(),
     Page#page_context.module.
 
@@ -330,7 +351,7 @@ entry_point(EntryPoint) ->
     Page = page_context(),
     page_context(Page#page_context { entry_point = EntryPoint}).
 
-path_info() -> 
+path_info() ->
     Page = page_context(),
     Page#page_context.path_info.
 
@@ -397,7 +418,7 @@ event_handle_invalid(HandleInvalid) ->
     Event = event_context(),
     event_context(Event#event_context { handle_invalid = HandleInvalid }).
 
-    
+
 
 %%% HANDLERS %%%
 
@@ -444,31 +465,32 @@ init_context(Bridge) ->
         bridge = Bridge,
         page_context = #page_context { series_id = wf:temp_id() },
         event_context = #event_context {},
-        action_queue = new_action_queue(),		
+        action_queue = new_action_queue(),
         handler_list = [
             % Core handlers...
-            make_handler(config_handler, default_config_handler), 
+            make_handler(config_handler, default_config_handler),
             make_handler(log_handler, default_log_handler),
             make_handler(process_registry_handler, nprocreg_registry_handler),
-            make_handler(cache_handler, default_cache_handler), 
+            make_handler(cache_handler, default_cache_handler),
             make_handler(query_handler, default_query_handler),
             make_handler(crash_handler, default_crash_handler),
 
             % Stateful handlers...
-            make_handler(session_handler, simple_session_handler), 
-            make_handler(state_handler, default_state_handler), 
-            make_handler(identity_handler, default_identity_handler), 
-            make_handler(role_handler, default_role_handler), 
+            make_handler(session_handler, simple_session_handler),
+            make_handler(state_handler, default_state_handler),
+            make_handler(identity_handler, default_identity_handler),
+            make_handler(role_handler, default_role_handler),
 
             % Handlers that possibly redirect...
-            make_handler(route_handler, dynamic_route_handler), 
+            make_handler(route_handler, dynamic_route_handler),
             make_handler(security_handler, default_security_handler)
-        ]
+        ],
+        script_nonce = wf_security_policy:nonce()
     },
     context(Context).
 
-make_handler(Name, Module) -> 
-    #handler_context { 
+make_handler(Name, Module) ->
+    #handler_context {
         name=Name,
         module=Module,
         state=[]
@@ -483,11 +505,11 @@ caching(Caching) ->
     context(Context#context{caching=Caching}).
 
 %%% GET AND SET CONTEXT %%%
-% Yes, the context is stored in the process dictionary. It makes the Nitrogen 
+% Yes, the context is stored in the process dictionary. It makes the Nitrogen
 % code much cleaner. Trust me.
-context() -> 
+context() ->
     get(context).
-context(Context) -> 
+context(Context) ->
     put(context, Context).
 
 %% for debugging. Remove when ready

--- a/src/lib/wf_cookies.erl
+++ b/src/lib/wf_cookies.erl
@@ -54,10 +54,10 @@ set_websocket_cookie(Cookie, Value, Options) ->
         http_only=proplists:get_value(http_only, Options, false)
     },
     wf:wire(SetCookie).
-	
+
 set_bridge_cookie(Cookie, Value, Options) ->
 	Bridge = wf_context:bridge(),
-    Options2 = minutes_to_live_to_max_age(Options),
+  Options2 = minutes_to_live_to_max_age(Options),
 	NewBridge = sbw:set_cookie(Cookie, Value, Options2, Bridge),
 	wf_context:bridge(NewBridge),
     ok.

--- a/src/lib/wf_security_policy.erl
+++ b/src/lib/wf_security_policy.erl
@@ -1,0 +1,72 @@
+% vim: sw=4 ts=4 et ft=erlang
+-module(wf_security_policy).
+-include("wf.hrl").
+
+-export([
+          generate/0
+        , nonce/0
+        ]).
+
+generate() ->
+    case wf:config_default(content_security_policy, []) of
+        [] ->
+            undefined;
+        Spec ->
+            build_csp(Spec)
+    end.
+
+build_csp(Spec) when is_list(Spec) ->
+    lists:foldl(fun process_csp_rule/2, [], Spec);
+build_csp(Spec) ->
+    Spec.
+
+process_csp_rule({Domain, Sources}, Acc) ->
+    NormalizedSources = string:join([source(S) || S <- Sources], " "),
+    domain(Domain) ++ " " ++ NormalizedSources ++ "; " ++ Acc.
+
+%% create a random nonce value; hard coded to be 12 characters
+nonce() ->
+    Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+    Length = length(Chars),
+    lists:foldl(
+      fun(_, Acc) ->
+              [lists:nth(rand:uniform(Length), Chars)] ++ Acc
+      end, [], lists:seq(1, 12)).
+
+
+%% allow atomized aliases for CSP domains
+domain(default_src)     -> "default-src";
+domain(script_src)      -> "script-src";
+domain(style_src)       -> "style-src";
+domain(img_src)         -> "img-src";
+domain(connect_src)     -> "connect-src";
+domain(font_src)        -> "font-src";
+domain(object_src)      -> "object-src";
+domain(media_src)       -> "media-src";
+domain(frame_src)       -> "frame-src";
+domain(sandbox)         -> "sandbox";
+domain(report_uri)      -> "report-uri";
+domain(child_src)       -> "child-src";
+domain(form_action)     -> "form-action";
+domain(frame_ancestors) -> "frame-ancestors";
+domain(plugin_types)    -> "plugin-types";
+domain(base_uri)        -> "base-uri";
+domain(report_to)       -> "report-to";
+domain(worker_src)      -> "worker-src";
+domain(manifest_src)    -> "manifest-src";
+domain(prefetch_src)    -> "prefetch-src";
+domain(navigate_to)     -> "navigate-to";
+domain(Domain)          -> Domain.
+
+
+%% allow atomized aliases for CSP sources
+source(none)           -> "'none'";
+source(self)           -> "'self'";
+source(data)           -> "'data:'";
+source(https)          -> "'https:'";
+source(unsafe_inline)  -> "'unsafe-inline'";
+source(unsafe_eval)    -> "'unsafe-eval'";
+source(strict_dynamic) -> "'strict-dynamic'";
+source(unsafe_hashes)  -> "'unsafe-hashes'";
+source(nonce)          -> "'nonce-" ++ wf:script_nonce() ++ "'";
+source(Source)         -> Source.

--- a/src/wf.erl
+++ b/src/wf.erl
@@ -8,13 +8,13 @@
 -compile (export_all).
 
 %%% EXPOSE WIRE, UPDATE, FLASH %%%
-wire(Actions) -> 
+wire(Actions) ->
     ok = wire(undefined, undefined, Actions).
 
-wire(Target, Actions) -> 
+wire(Target, Actions) ->
     ok = wire(Target, Target, Actions).
 
-wire(Trigger, Target, Actions) -> 
+wire(Trigger, Target, Actions) ->
     ok = action_wire:wire(Trigger, Target, Actions).
 
 defer(Actions) ->
@@ -50,10 +50,10 @@ priority_wire(normal, Trigger, Target, Actions) ->
 priority_wire(defer, Trigger, Target, Actions) ->
     ok = wf:defer(Trigger, Target, Actions).
 
-set(Element, Value) -> 
+set(Element, Value) ->
     ok = set(normal, Element, Value).
 
-set(Priority, Element, Value) when ?IS_ACTION_PRIORITY(Priority) -> 
+set(Priority, Element, Value) when ?IS_ACTION_PRIORITY(Priority) ->
     ok = action_set:set(Priority, Element, Value).
 
 set_multiple(Element, Values) ->
@@ -61,9 +61,9 @@ set_multiple(Element, Values) ->
 
 set_multiple(Priority, Element, Values) when is_list(Values), ?IS_ACTION_PRIORITY(Priority) ->
     ok = action_set_multiple:set(Priority, Element, Values).
-      
 
-update(Target, Elements) -> 
+
+update(Target, Elements) ->
     ok = update(normal, Target, Elements).
 
 update(Priority, Target, Elements) when ?IS_ACTION_PRIORITY(Priority) ->
@@ -75,13 +75,13 @@ replace(Target, Elements) ->
 replace(Priority, Target, Elements) when ?IS_ACTION_PRIORITY(Priority) ->
     ok = action_update:replace(Priority, Target, Elements).
 
-insert_top(Target, Elements) -> 
+insert_top(Target, Elements) ->
     ok = insert_top(normal, Target, Elements).
 
-insert_top(Priority, Target, Elements) when ?IS_ACTION_PRIORITY(Priority) -> 
+insert_top(Priority, Target, Elements) when ?IS_ACTION_PRIORITY(Priority) ->
     ok = action_update:insert_top(Priority, Target, Elements).
 
-insert_bottom(Target, Elements) -> 
+insert_bottom(Target, Elements) ->
     ok = insert_bottom(normal, Target, Elements).
 
 insert_bottom(Priority, Target, Elements) when ?IS_ACTION_PRIORITY(Priority) ->
@@ -110,7 +110,7 @@ disable(Target) ->
 
 disable(Priority, Target) when ?IS_ACTION_PRIORITY(Priority) ->
     ok = action_disable:disable(Priority, Target).
- 
+
 enable(Target) ->
     ok = enable(normal, Target).
 
@@ -125,34 +125,34 @@ flash(FlashID, Elements) ->
 
 %%% EXPOSE WF_UTILS %%%
 
-f(S) -> 
+f(S) ->
     _String = wf_utils:f(S).
 
-f(S, Args) -> 
+f(S, Args) ->
     _String = wf_utils:f(S, Args).
 
-coalesce(L) -> 
+coalesce(L) ->
     _Value = wf_utils:coalesce(L).
 
 %%% WF_REDIRECT %%%
-redirect(Url) -> 
+redirect(Url) ->
     action_redirect:redirect(Url).
 
-redirect_to_login(LoginUrl) -> 
+redirect_to_login(LoginUrl) ->
     action_redirect:redirect_to_login(LoginUrl).
 
 redirect_to_login(LoginUrl, PostLoginUrl) ->
     action_redirect:redirect_to_login(LoginUrl, PostLoginUrl).
 
-redirect_from_login(DefaultUrl) -> 
+redirect_from_login(DefaultUrl) ->
     action_redirect:redirect_from_login(DefaultUrl).
 
 
 %%% EXPOSE WF_PICKLE %%%
-pickle(Data) -> 
+pickle(Data) ->
     _SerializedData = wf_pickle:pickle(Data).
 
-depickle(SerializedData) -> 
+depickle(SerializedData) ->
     _Data = wf_pickle:depickle(SerializedData).
 
 depickle(SerializedData, TTLSeconds) ->
@@ -160,25 +160,25 @@ depickle(SerializedData, TTLSeconds) ->
 
 
 %%% EXPOSE WF_CONVERT %%%
-to_list(T) -> 
+to_list(T) ->
     _String = wf_convert:to_list(T).
 
 to_unicode_list(T) ->
     _String = wf_convert:to_unicode_list(T).
 
-to_atom(T) -> 
+to_atom(T) ->
     _Atom = wf_convert:to_atom(T).
 
 to_existing_atom(T) ->
     _Atom = wf_convert:to_existing_atom(T).
 
-to_binary(T) -> 
+to_binary(T) ->
     _Binary = wf_convert:to_binary(T).
 
 to_unicode_binary(T) ->
     _Binary = wf_convert:to_unicode_binary(T).
 
-to_integer(T) -> 
+to_integer(T) ->
     _Integer = wf_convert:to_integer(T).
 
 to_float(T) ->
@@ -187,13 +187,13 @@ to_float(T) ->
 to_string_list(Term) ->
     _StringList = wf_convert:to_string_list(Term).
 
-clean_lower(S) -> 
+clean_lower(S) ->
     _String = wf_convert:clean_lower(S).
 
-html_encode(S) -> 
+html_encode(S) ->
     _String = wf_convert:html_encode(S).
 
-html_encode(S, Encode) -> 
+html_encode(S, Encode) ->
     _String = wf_convert:html_encode(S, Encode).
 
 html_decode(S) ->
@@ -211,7 +211,7 @@ hex_encode(S) ->
 hex_decode(S) ->
     _String = wf_convert:hex_decode(S).
 
-js_escape(String) -> 
+js_escape(String) ->
     _String = wf_convert:js_escape(String).
 
 json_encode(Data) ->
@@ -240,10 +240,10 @@ join(List,Delimiter) ->
 
 logout() -> clear_user(), clear_roles(), clear_state(), clear_session().
 
-to_js_id(Path) -> 
+to_js_id(Path) ->
     _String = wf_render_actions:to_js_id(Path).
 
-temp_id() -> 
+temp_id() ->
     _String = wf_render_elements:temp_id().
 
 normalize_id(Path) ->
@@ -259,7 +259,7 @@ render_isolated(Elements) ->
 in_request() ->
     wf_context:in_request().
 
-page_module() -> 
+page_module() ->
     wf_context:page_module().
 
 page_module(Mod) ->
@@ -277,7 +277,7 @@ uri() ->
 url() ->
     wf_context:url().
 
-status_code() -> 
+status_code() ->
     ok = wf_context:status_code().
 
 status_code(StatusCode) ->
@@ -295,7 +295,7 @@ encoding(Encoding) ->
 download_as(Filename) ->
     wf_context:download_as(Filename).
 
-headers() -> 
+headers() ->
     wf_context:headers().
 
 header(Header) ->
@@ -318,6 +318,12 @@ cookie(Cookie, Value) ->
 
 cookie(Cookie, Value, Options) ->
     ok = wf_cookies:set_cookie(Cookie, Value, Options).
+
+script_nonce() ->
+  wf_context:script_nonce().
+
+script_nonce(Value) ->
+  wf_context:script_nonce(Value).
 
 %% Deprecated
 cookie(Cookie, Value, Path, MinutesToLive) ->
@@ -345,10 +351,10 @@ request_body() ->
     wf_context:request_body().
 
 %%% EXPOSE QUERY_HANDLER %%%
-q(Key) -> 
+q(Key) ->
     _String = query_handler:get_value(Key).
 
-qs(Key) -> 
+qs(Key) ->
     query_handler:get_values(Key).
 
 mq(KeyList) when is_list(KeyList) ->
@@ -377,22 +383,22 @@ params() ->
 
 
 %%% EXPOSE LOG_HANDLER %%%
-info(String, Args) -> 
+info(String, Args) ->
     ok = log_handler:info(String, Args).
 
-info(String) -> 
+info(String) ->
     ok = log_handler:info(String).
 
-warning(String, Args) -> 
+warning(String, Args) ->
     ok = log_handler:warning(String, Args).
 
-warning(String) -> 
+warning(String) ->
     ok = log_handler:warning(String).
 
-error(String, Args) -> 
+error(String, Args) ->
     ok = log_handler:error(String, Args).
 
-error(String) -> 
+error(String) ->
     ok = log_handler:error(String).
 
 %% console_log is not part of the log handler, but  relevant
@@ -402,17 +408,17 @@ console_log(String) ->
 console_log(Priority, String) ->
     action_console_log:console_log(Priority, String).
 
-%%% EXPOSE SESSION_HANDLER %%% 
-session(Key) -> 
+%%% EXPOSE SESSION_HANDLER %%%
+session(Key) ->
     _Value = session_handler:get_value(Key).
 
-session(Key, Value) -> 
+session(Key, Value) ->
     _Value = session_handler:set_value(Key, Value).
 
 session_default(Key, DefaultValue) ->
     _Value = session_handler:get_value(Key, DefaultValue).
 
-clear_session() -> 
+clear_session() ->
     ok = session_handler:clear_all().
 
 session_id() ->
@@ -443,59 +449,59 @@ clear_all_cache() ->
     ok = cache_handler:clear_all().
 
 %%% EXPOSE IDENTITY_HANDLER %%%
-user() -> 
-    _User = identity_handler:get_user().    
+user() ->
+    _User = identity_handler:get_user().
 
-user(User) -> 
+user(User) ->
     ok = identity_handler:set_user(User).
 
-clear_user() -> 
+clear_user() ->
     ok = identity_handler:clear().
 
 
 
 %%% EXPOSE ROLE_HANDLER %%%
-role(Role) -> 
+role(Role) ->
     _Boolean = role_handler:get_has_role(Role).
 
-role(Role, IsInRole) -> 
+role(Role, IsInRole) ->
     ok = role_handler:set_has_role(Role, IsInRole).
 
 roles() ->
     _Roles = role_handler:get_roles().
 
-clear_roles() -> 
+clear_roles() ->
     ok = role_handler:clear_all().
 
 
 
 %%% EXPOSE STATE_HANDLER %%%
-state(Key) -> 
+state(Key) ->
     _Value = state_handler:get_state(Key).
 
 state_default(Key, DefaultValue) ->
     _Value = state_handler:get_state(Key, DefaultValue).
 
-state(Key, Value) -> 
+state(Key, Value) ->
     ok = state_handler:set_state(Key, Value).
 
 clear_state(Key) ->
     ok = state_handler:clear(Key).
 
-clear_state() -> 
+clear_state() ->
     ok = state_handler:clear_all().
 
 
 
 %%% EXPOSE ACTION_COMET %%%
 
-comet(Function) -> 
+comet(Function) ->
     action_comet:comet(Function).
 
-comet(Function, Pool) -> 
+comet(Function, Pool) ->
     action_comet:comet(Function, Pool).
 
-comet_global(Function, Pool) ->  
+comet_global(Function, Pool) ->
     action_comet:comet_global(Function, Pool).
 
 send(Pool, Message) ->
@@ -521,10 +527,10 @@ continue(Tag, Function, TimeoutMS) -> action_continue:continue(Tag, Function, Ti
 
 %%% CONFIGURATION %%%
 
-config(Key) -> 
+config(Key) ->
     config_handler:get_value(Key).
 
-config_default(Key, DefaultValue) -> 
+config_default(Key, DefaultValue) ->
     config_handler:get_value(Key, DefaultValue).
 
 %%% DEBUGGING %%%

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -10,18 +10,18 @@
     serialize_context/0
 ]).
 
-% nitrogen_core - 
+% nitrogen_core -
 % --
 % Render a single Nitrogen page or inline application. This can be called
-% from other Erlang web frameworks or resource servers, such as WebMachine, 
+% from other Erlang web frameworks or resource servers, such as WebMachine,
 % Erlang Web, ErlyWeb, etc.
 
 run() ->
     Bridge = wf_context:bridge(),
-    try 
+    try
         case sbw:error(Bridge) of
             none -> run_catched();
-            Other -> 
+            Other ->
                 Message = wf:f("Errors: ~p~n", [Other]),
                 Bridge1 = sbw:set_response_data(Message, Bridge),
                 sbw:build_response(Bridge1)
@@ -29,11 +29,11 @@ run() ->
     catch
         exit:normal ->
             exit(normal);
-        Type : Error -> 
+        Type : Error ->
             run_crash(Bridge, Type, Error, erlang:get_stacktrace())
     end.
 
-    
+
 
 run_crash(Bridge, Type, Error, Stacktrace) ->
     try
@@ -86,13 +86,13 @@ run_catched() ->
     call_init_on_handlers(),
     wf_event:update_context_with_event(wf:q(eventContext)),
     case wf_context:type() of
-        first_request    -> 
-            run_first_request(), 
+        first_request    ->
+            run_first_request(),
             finish_dynamic_request();
-        postback_request -> 
-            run_postback_request(), 
+        postback_request ->
+            run_postback_request(),
             finish_dynamic_request();
-        static_file      -> 
+        static_file      ->
             finish_static_request()
     end.
 
@@ -195,9 +195,9 @@ deserialize_context(SerializedPageContext) ->
 
 %%% SET UP AND TEAR DOWN HANDLERS %%%
 
-% init_handlers/1 - 
+% init_handlers/1 -
 % Handlers are initialized in the order that they exist in #context.handlers. The order
-% is important, as some handlers may depend on others being initialize. For example, 
+% is important, as some handlers may depend on others being initialize. For example,
 % the session handler may use the cookie handler to get or set the session cookie.
 % TODO: Re-evaluate handlers into some form of middleware layer or something.
 % Allowing us to pass handler contexts from one handler to another and limit
@@ -211,12 +211,12 @@ call_init_on_handlers() ->
     [wf_handler:init(X) || X <- Handlers],
     ok.
 
-% finish_handlers/1 - 
+% finish_handlers/1 -
 % Handlers are finished in the order that they exist in #context.handlers. The order
 % is important, as some handlers should finish after others.
 call_finish_on_handlers() ->
     [wf_handler:finish(X) || X <- wf_context:handlers()],
-    ok.	
+    ok.
 
 
 %%% FIRST REQUEST %%%
@@ -269,6 +269,7 @@ build_first_response(Html, Script) ->
     Html2 = encode(Html1),
 
     % Update the response bridge and return.
+    wf_context:content_security_policy(),
     Bridge = wf_context:bridge(),
     Bridge1 = sbw:set_response_data(Html2, Bridge),
     sbw:build_response(Bridge1).
@@ -290,7 +291,7 @@ replace_script(Script, [H|T]) -> [replace_script(Script, H)|replace_script(Scrip
 replace_script(_, Other) -> Other.
 
 encode(Text) ->
-    Encoding = wf_context:encoding(), 
+    Encoding = wf_context:encoding(),
     encode(Encoding, Text).
 
 -spec encode(encoding(), iolist()) -> iolist().


### PR DESCRIPTION
## Rationale

Content Security Policies are the Next Great Thing (at least in larger organizations).  There are two parts to implementing CSPs:

1.  Generating a nonce value that can be attached to inline `<style>` and `<script>` tags.

2.  Generating a Content-Security-Policy header.

In an attempt to off load the tedium of implementing these features ad hoc for individual projects, I'd offer that allowing nitrogen_core to perform these tasks will result in less boilerplate code and provide a uniform means of developing Nitrogen apps making use of CSPs.

## Summary

The CSP for a configuration can be configured via the application environment in the the appropriate config file.  Some effort has been made to make this an Erlang-friendly process: CSP domains (e.g., "script-src", "style-src") are available as atoms (script_src, style_src); source keywords (e.g., 'self', 'unsafe-eval') are also available as atoms (self, unsafe_eval). Furthermore, the source keyword `nonce` is expanded to `nonce-<current-nonce-value>` in the header.

The nonce value can be retrieved via `wf:script_nonce/0`, `script_nonce` now being a new attribute of the `#context` record.  This may be called out to from templates.

In the case where `content_security_policy` is not defined in the application environment, no header is set.

## Examples

### In app.config:

```erlang
 {nitrogen_core,
  [{content_security_policy,
    [ 
      {default_src, [none]}
    , {script_src, [self, nonce, unsafe_eval,
                    "cdnjs.cloudflare.com",
                    "code.jquery.com",
                    "stackpath.bootstrapcdn.com",
                    "kit.fontawesome.com"]}
    , {connect_src, [self,
                     "*.fontawesome.com",
                     "ws://localhost:12303"]}
    , {img_src, [self]}
    , {base_uri, [self]}
    , {font_src, [self,
                  "use.fontawesome.com"]}
    , {style_src, [self,
                   nonce,
                   "*.fontawesome.com",
                   "stackpath.bootstrapcdn.com"]}
    , {form_action, [self]}
    ]}, ...
```

### In a template file:

```html
    <script nonce="[[[wf:script_nonce()]]]">
     [[[script]]]
    </script>
```


## Notes

I honestly wasn't sure where to set the header.  It ended up in `wf_core:build_first_response/2` but I'm not sure that's correct.  Any guidance would be appreciated!  (I believe this is the only type of response that requires the header.)

Make no mistake: this is non-trivial to use.  For reasons I haven't yet grokked, a construct like:

```html
<div style="..." nonce="...">
```

does not pass muster in Safari (although it does in Firefox).  The "correct" way to do this is to define the ad hoc style as a CSS class and mark the element as belonging to the class.  It's tempting to suggest that `nonce :: boolean()` might be an appropriate new attribute to the `#element_base` record; when the element is rendered `nonce=xxx` could be added or not depending.  Given that this simply doesn't work on one of the major browsers (but I'm still investigating), I'm not sure that it doesn't give a developer a false sense of correctness.

I'm sorry about the whitespace changes, I know they make the diff harder to read.  I'm happy enough to re-submit if this is an issue.

Thank-you for your feedback in #125. I'll close that PR as I believe this work entirely supersedes what I was getting at there.
