### PR TITLE
implemented postback_handler

### DIFF
--- a/doc/markdown/handlers.md
+++ b/doc/markdown/handlers.md
@@ -5,7 +5,7 @@
 
 ## Handler Overview
 
-Core Nitrogen behavior has been broken out into well-defined, pluggable 
+Core Nitrogen behavior has been broken out into well-defined, pluggable
 behavior modules called /handlers/. Handlers allow you to easily substitute
 your own logic for things like session, security, routing, and others. Simply
 create a module that implements one of the existing behaviors, and register it
@@ -97,3 +97,5 @@ In all of the handler behavior functions are found two particular variables:
  *  [Security Handler](security.md) - Controls whether or not a user
     has access to a resource, and if not, should determine what to do with
     the request.
+ *  [Postback Handler](postback.md) - Controls how postback requests
+    are handled.

--- a/doc/markdown/postback.md
+++ b/doc/markdown/postback.md
@@ -1,0 +1,61 @@
+<!-- dash: Handlers - Postback | Guide | ###:Section -->
+
+## Postback Handler
+
+The postback handler.  `postback_request/2` is called on each postback
+request.  The default postback handler does not implement any behavior.
+
+### Behavior Functions
+
+##### `init(Config, State)`
+
+Initialize the handler.
+
+ * /Return Value/ - `{ok, NewState}`
+
+##### `finish(Config, State)`
+
+Clean up the handler.
+
+ * /Return Value/ - `{ok, NewState}`
+
+##### `postback_request(Config, State)`
+
+Called on each postback request.  Of particular interest are the
+values of and assignment to `wf_context:event_module/0,1` and
+`wf_context:event_tag/0,1`.  The example below demonstrates.
+
+The return values is discarded; this function is called solely for its
+side effects.
+
+### Example
+
+Here we opt to run `other_module:event/1` in place of the original
+event/1 callback if the postback tag matches `{_, exception}`.
+
+``` erlang
+-module(reroute_postback_handler).
+-behaviour(postback_handler).
+-include_lib("wf.hrl").
+-export([
+          init/2
+        , finish/2
+        , postback_request/2
+        ]).
+
+init(_Config, State) ->
+    {ok, State}.
+
+finish(_Config, State) ->
+    {ok, State}.
+
+postback_request(_Config, _State) ->
+  case wf_context:event_tag() of
+    {_, exception} -> wf_context:event_module(other_module);
+    _              -> ok
+  end.
+```
+
+ ### See Also
+
+ *  [Handler Overview](./handlers.md)

--- a/src/handlers/postback/default_postback_handler.erl
+++ b/src/handlers/postback/default_postback_handler.erl
@@ -1,0 +1,22 @@
+% vim: sw=4 ts=4 et ft=erlang
+% Nitrogen Web Framework for Erlang
+% See MIT-LICENSE for licensing information.
+
+-module (default_postback_handler).
+-behaviour (postback_handler).
+-include("wf.hrl").
+-export ([
+    init/2,
+    finish/2,
+    postback_request/2
+]).
+
+
+init(_Config, State) ->
+    {ok, State}.
+
+finish(_Config, State) ->
+    {ok, State}.
+
+postback_request(_Config, _State) ->
+    ok.

--- a/src/handlers/postback/postback_handler.erl
+++ b/src/handlers/postback/postback_handler.erl
@@ -1,0 +1,20 @@
+% vim: sw=4 ts=4 et ft=erlang
+% Nitrogen Web Framework for Erlang
+% See MIT-LICENSE for licensing information.
+
+-module (postback_handler).
+-include("wf.hrl").
+-export([ postback_request/0 ]).
+
+-callback init(handler_config(),
+               handler_state()) -> {ok, handler_state()}.
+
+-callback finish(handler_config(),
+                 handler_state()) -> {ok, handler_state()}.
+
+-callback postback_request(handler_config(),
+                           handler_state()) -> {ok, handler_state()}.
+
+
+postback_request() ->
+    _Value = wf_handler:call_readonly(postback_handler, postback_request, []).

--- a/src/handlers/postback/postback_handler.erl
+++ b/src/handlers/postback/postback_handler.erl
@@ -13,7 +13,7 @@
                  handler_state()) -> {ok, handler_state()}.
 
 -callback postback_request(handler_config(),
-                           handler_state()) -> {ok, handler_state()}.
+                           handler_state()) -> any().
 
 
 postback_request() ->

--- a/src/lib/wf_context.erl
+++ b/src/lib/wf_context.erl
@@ -56,7 +56,7 @@
 
         page_context/0,
         page_context/1,
-       
+
         entry_point/0,
         entry_point/1,
 
@@ -314,7 +314,7 @@ series_id(SeriesID) ->
     Page = page_context(),
     page_context(Page#page_context { series_id = SeriesID }).
 
-page_module() -> 
+page_module() ->
     Page = page_context(),
     Page#page_context.module.
 
@@ -330,7 +330,7 @@ entry_point(EntryPoint) ->
     Page = page_context(),
     page_context(Page#page_context { entry_point = EntryPoint}).
 
-path_info() -> 
+path_info() ->
     Page = page_context(),
     Page#page_context.path_info.
 
@@ -397,7 +397,7 @@ event_handle_invalid(HandleInvalid) ->
     Event = event_context(),
     event_context(Event#event_context { handle_invalid = HandleInvalid }).
 
-    
+
 
 %%% HANDLERS %%%
 
@@ -444,31 +444,33 @@ init_context(Bridge) ->
         bridge = Bridge,
         page_context = #page_context { series_id = wf:temp_id() },
         event_context = #event_context {},
-        action_queue = new_action_queue(),		
+        action_queue = new_action_queue(),
         handler_list = [
             % Core handlers...
-            make_handler(config_handler, default_config_handler), 
+            make_handler(config_handler, default_config_handler),
             make_handler(log_handler, default_log_handler),
             make_handler(process_registry_handler, nprocreg_registry_handler),
-            make_handler(cache_handler, default_cache_handler), 
+            make_handler(cache_handler, default_cache_handler),
             make_handler(query_handler, default_query_handler),
             make_handler(crash_handler, default_crash_handler),
 
             % Stateful handlers...
-            make_handler(session_handler, simple_session_handler), 
-            make_handler(state_handler, default_state_handler), 
-            make_handler(identity_handler, default_identity_handler), 
-            make_handler(role_handler, default_role_handler), 
+            make_handler(session_handler, simple_session_handler),
+            make_handler(state_handler, default_state_handler),
+            make_handler(identity_handler, default_identity_handler),
+            make_handler(role_handler, default_role_handler),
 
             % Handlers that possibly redirect...
-            make_handler(route_handler, dynamic_route_handler), 
-            make_handler(security_handler, default_security_handler)
+            make_handler(route_handler, dynamic_route_handler),
+            make_handler(security_handler, default_security_handler),
+            make_handler(postback_handler, default_postback_handler)
+
         ]
     },
     context(Context).
 
-make_handler(Name, Module) -> 
-    #handler_context { 
+make_handler(Name, Module) ->
+    #handler_context {
         name=Name,
         module=Module,
         state=[]
@@ -483,11 +485,11 @@ caching(Caching) ->
     context(Context#context{caching=Caching}).
 
 %%% GET AND SET CONTEXT %%%
-% Yes, the context is stored in the process dictionary. It makes the Nitrogen 
+% Yes, the context is stored in the process dictionary. It makes the Nitrogen
 % code much cleaner. Trust me.
-context() -> 
+context() ->
     get(context).
-context(Context) -> 
+context(Context) ->
     put(context, Context).
 
 %% for debugging. Remove when ready

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -10,18 +10,18 @@
     serialize_context/0
 ]).
 
-% nitrogen_core - 
+% nitrogen_core -
 % --
 % Render a single Nitrogen page or inline application. This can be called
-% from other Erlang web frameworks or resource servers, such as WebMachine, 
+% from other Erlang web frameworks or resource servers, such as WebMachine,
 % Erlang Web, ErlyWeb, etc.
 
 run() ->
     Bridge = wf_context:bridge(),
-    try 
+    try
         case sbw:error(Bridge) of
             none -> run_catched();
-            Other -> 
+            Other ->
                 Message = wf:f("Errors: ~p~n", [Other]),
                 Bridge1 = sbw:set_response_data(Message, Bridge),
                 sbw:build_response(Bridge1)
@@ -29,11 +29,11 @@ run() ->
     catch
         exit:normal ->
             exit(normal);
-        Type : Error -> 
+        Type : Error ->
             run_crash(Bridge, Type, Error, erlang:get_stacktrace())
     end.
 
-    
+
 
 run_crash(Bridge, Type, Error, Stacktrace) ->
     try
@@ -86,13 +86,13 @@ run_catched() ->
     call_init_on_handlers(),
     wf_event:update_context_with_event(wf:q(eventContext)),
     case wf_context:type() of
-        first_request    -> 
-            run_first_request(), 
+        first_request    ->
+            run_first_request(),
             finish_dynamic_request();
-        postback_request -> 
-            run_postback_request(), 
+        postback_request ->
+            run_postback_request(),
             finish_dynamic_request();
-        static_file      -> 
+        static_file      ->
             finish_static_request()
     end.
 
@@ -195,9 +195,9 @@ deserialize_context(SerializedPageContext) ->
 
 %%% SET UP AND TEAR DOWN HANDLERS %%%
 
-% init_handlers/1 - 
+% init_handlers/1 -
 % Handlers are initialized in the order that they exist in #context.handlers. The order
-% is important, as some handlers may depend on others being initialize. For example, 
+% is important, as some handlers may depend on others being initialize. For example,
 % the session handler may use the cookie handler to get or set the session cookie.
 % TODO: Re-evaluate handlers into some form of middleware layer or something.
 % Allowing us to pass handler contexts from one handler to another and limit
@@ -211,12 +211,12 @@ call_init_on_handlers() ->
     [wf_handler:init(X) || X <- Handlers],
     ok.
 
-% finish_handlers/1 - 
+% finish_handlers/1 -
 % Handlers are finished in the order that they exist in #context.handlers. The order
 % is important, as some handlers should finish after others.
 call_finish_on_handlers() ->
     [wf_handler:finish(X) || X <- wf_context:handlers()],
-    ok.	
+    ok.
 
 
 %%% FIRST REQUEST %%%
@@ -240,6 +240,7 @@ run_crashed_first_request(Type, Error, Stacktrace) ->
 %%% POSTBACK REQUEST %%%
 
 run_postback_request() ->
+    postback_handler:postback_request(),
     Module = wf_context:event_module(),
     Tag = wf_context:event_tag(),
     HandleInvalid = wf_context:event_handle_invalid(),
@@ -290,7 +291,7 @@ replace_script(Script, [H|T]) -> [replace_script(Script, H)|replace_script(Scrip
 replace_script(_, Other) -> Other.
 
 encode(Text) ->
-    Encoding = wf_context:encoding(), 
+    Encoding = wf_context:encoding(),
     encode(Encoding, Text).
 
 -spec encode(encoding(), iolist()) -> iolist().


### PR DESCRIPTION
## Rationale 

Currently there's no (obvious[*]) way to intercept and possibly modify postback requests.  This PR creates a new handler, `postback_handler`, that calls the function `postback_handler:postback_request/0` as the first instruction in `wf_core:run_postback_request/0`.  The handler has access to, and the ability to modify, event_module and event_tag.

There are a number of potential uses.  My motivation is to provide a mechanism to reset an inactivity timer (or shunt the user to a login page if too much time has elapsed).  Additional possibilities that immediately come to mind include:

* dynamic re-routing based on the event_tag;
* global debugging instrumentation;
* auditing of requests in "one page" webapps.

[*] It **is** possible to piggyback on query_handler:set_websocket_params/3.  This, however, has the disadvantage of requiring duplicated code and is a real gotcha for a maintainer.

## Thoughts

It's yet more code to execute on every request.  In the default case this has no more overhead than default_security_handler but it all adds up.  I'm also not sure that it's generally useful or even something to be encouraged.

When I started thinking about this I had the idea of mod_perl's fixup handler in mind.  That's described in the documentation as:

> The fixups phase is happening just before the content handling phase. It gives the last chance to do things before the response is generated.

As I dug into the Nitrogen code and thought about the semantics of the existing handlers, there's not a lot to be gained (and clarity to be lost) with a handler that generic.  I think.  I'd welcome any thoughts you have!

##  Example

```erlang
-module(nxo_postback_handler).
-behaviour(postback_handler).
-include("nxo.hrl").
-export([
          init/2
        , finish/2
        , postback_request/2
        ]).

init(_Config, State) ->
    {ok, State}.

finish(_Config, State) ->
    {ok, State}.

postback_request(_Config, _State) ->
  case wf_context:event_tag() of
    {do_something, _} -> wf_context:event_module(fake_index);
    _                 -> ok
  end.
```
