### PR TITLE
Correct example for tableheader elements

### DIFF
--- a/doc/markdown/table.md
+++ b/doc/markdown/table.md
@@ -10,11 +10,11 @@ The table element allows you to build an HTML table in Nitrogen.
 
 ```erlang
 
-   #table { rows=[
+   #table { header=[
      #tablerow { cells=[
        #tableheader { text="Name" },
        #tableheader { text="Location" }
-     ]},
+     ]}], rows=[
      #tablerow { cells=[
        #tablecell { text="Rusty" },
        #tablecell { text="USA" }


### PR DESCRIPTION
tableheader elements should be in the header, not the body.