### PR TITLE
Reconcile different default values for cookie_name

### DIFF
--- a/src/handlers/session/simple_session_handler.erl
+++ b/src/handlers/session/simple_session_handler.erl
@@ -74,7 +74,7 @@ session_id(_Config, State) ->
 %%% PRIVATE FUNCTIONS
 
 get_cookie_name() ->
-    wf:config_default(cookie_name, "newcookie").
+    wf:config_default(cookie_name, "wf").
 
 get_session_pid(_Config, State) ->
     Timeout = wf:config_default(session_timeout, 20),


### PR DESCRIPTION
The default value given in nitrogen/rel/overlay/common/etc/app.config is "wf"