### PR TITLE
Logging: change `?LOG` macro to `?WF_LOG`

### DIFF
--- a/doc/markdown/crash.md
+++ b/doc/markdown/crash.md
@@ -99,7 +99,7 @@ finish(_Config, State) ->
 
 first_request(Type, Error, Stacktrace, _Config, _State) ->
     %% Print the error message to the Erlang console
-    ?LOG("~p~n", [{error, Type, Error, Stacktrace}]),
+    ?WF_LOG("~p~n", [{error, Type, Error, Stacktrace}]),
 
     %% Set the response status code to 500 (internal server error)
     wf:status_code(500),
@@ -109,7 +109,7 @@ first_request(Type, Error, Stacktrace, _Config, _State) ->
 
 postback_request(Type, Error, Stacktrace, _Config, _State) ->
     %% Print the error message to the Erlang console
-    ?LOG("~p~n", [{error, Type, Error, Stacktrace}]),
+    ?WF_LOG("~p~n", [{error, Type, Error, Stacktrace}]),
 
     %% Set the status code to 500 (internal server error)
     wf:status_code(500),
@@ -143,7 +143,7 @@ finish(_Config, State) ->
 
 first_request(Type, Error, Stacktrace, _Config, _State) ->
     %% Print the error message to the Erlang console
-    ?LOG("~p~n", [{error, Type, Error, Stacktrace}]),
+    ?WF_LOG("~p~n", [{error, Type, Error, Stacktrace}]),
 
     %% Set the response status code to 500 (internal server error)
     wf:status_code(500),
@@ -164,7 +164,7 @@ body(Stacktrace) ->
 
 postback_request(Type, Error, Stacktrace, _Config, _State) ->
     %% Print the error message to the Erlang console
-    ?LOG("~p~n", [{error, Type, Error, Stacktrace}]),
+    ?WF_LOG("~p~n", [{error, Type, Error, Stacktrace}]),
 
     %% Note, we don't set the status code to 500. If we did, the browser will
     %% simply discard any javascript. So we keep a 200 status code and print

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -122,9 +122,20 @@
 %%% LOGGING %%%
 -ifndef(debug_print).
 -define(debug_print, true).
+
+-ifndef(LOGGER_HRL).
 -define(PRINT(Var), error_logger:info_msg("DEBUG: ~p~n~p:~p~n~p~n  ~p~n", [self(), ?MODULE, ?LINE, ??Var, Var])).
 -define(LOG(Msg, Args), error_logger:info_msg(Msg, Args)).
+-define(WF_LOG(Msg, Args), error_logger:info_msg(Msg, Args)).
 -define(DEBUG, error_logger:info_msg("DEBUG: ~p:~p~n", [?MODULE, ?LINE])).
+
+-else.
+%% logger.hrl has been included - avoid redefining the OTP ?LOG macro
+-define(WF_LOG(Msg, Args), ?LOG_INFO(Msg, Args)).
+-define(PRINT(Var), ?LOG_INFO("DEBUG: ~p: ~p~n", [??Var, Var])).
+-define(DEBUG, ?LOG_INFO("DEBUG: ~p:~p~n", [?MODULE, ?LINE])).
+-endif.
+
 -endif.
 
 %%% GUARDS %%%

--- a/src/handlers/crash/debug_crash_handler.erl
+++ b/src/handlers/crash/debug_crash_handler.erl
@@ -17,7 +17,7 @@ finish(_Config, State) ->
 
 first_request(Type, Error, Stacktrace, _Config, _State) ->
     Uri = wf:header(host) ++ wf:uri(),
-    ?LOG("~p~n", [{error, first_request, {url, Uri}, {Type, Error, Stacktrace}}]),
+    ?WF_LOG("~p~n", [{error, first_request, {url, Uri}, {Type, Error, Stacktrace}}]),
     wf:status_code(500),
     %% We use raw HTML here instead of Nitrogen elements in case the error is
     %% internal to nitrogen (like if the element rendering system is broken).
@@ -28,7 +28,7 @@ first_request(Type, Error, Stacktrace, _Config, _State) ->
 
 postback_request(Type, Error, Stacktrace, _Config, _State) ->
     Uri = wf:header(host) ++ wf:uri(),
-    ?LOG("~p~n", [{error, postback_request, {url, Uri}, {Type, Error, Stacktrace}}]),
+    ?WF_LOG("~p~n", [{error, postback_request, {url, Uri}, {Type, Error, Stacktrace}}]),
     ErrorMsg = <<"&#9888; An error occured performing this action. See console for details. &#9888;">>,
     CloseBtn = <<"<a style='float:right; color: #f00' href='javascript:' onclick='Nitrogen.$hide_notice_bar()'>[&times;]</a>">>,
     wf:wire([<<"Nitrogen.$show_notice_bar('error', \"">>, ErrorMsg , CloseBtn, <<"\")">>]),

--- a/src/handlers/crash/default_crash_handler.erl
+++ b/src/handlers/crash/default_crash_handler.erl
@@ -15,12 +15,12 @@ finish(_Config, State) ->
 	{ok, State}.
 
 first_request(Type, Error, Stacktrace, _Config, _State) ->
-	?LOG("~p~n", [{error, Type, Error, Stacktrace}]),
+	?WF_LOG("~p~n", [{error, Type, Error, Stacktrace}]),
 	wf:status_code(500),
 	"Internal Server Error".
 
 postback_request(Type, Error, Stacktrace, _Config, _State) ->
-	?LOG("~p~n", [{error, Type, Error, Stacktrace}]),
+	?WF_LOG("~p~n", [{error, Type, Error, Stacktrace}]),
 	wf:status_code(500),
 	wf:console_log("Postback Crashed. See console for details"),
 	ok.

--- a/src/wf_core.erl
+++ b/src/wf_core.erl
@@ -48,7 +48,7 @@ run_crash(Bridge, Type, Error, Stacktrace) ->
         exit:normal ->
             exit(normal);
         Type2:Error2 ->
-            ?LOG("Crash Handler Crashed:~n~p~n~nOriginal Crash:~n~p~n", [
+            ?WF_LOG("Crash Handler Crashed:~n~p~n~nOriginal Crash:~n~p~n", [
                 {Type2, Error2, erlang:get_stacktrace()},
                 {Type, Error, Stacktrace}]),
             Bridge1 = sbw:set_status_code(500, Bridge),
@@ -66,7 +66,7 @@ run_websocket_crash(Type, Error, Stacktrace) ->
         crash_handler:postback_request(Type, Error, Stacktrace),
         run_websocket_comet()
     catch Type2:Error2 ->
-        ?LOG("~p~n", [{error_in_crash_handler, Type2, Error2, erlang:get_stacktrace()}]),
+        ?WF_LOG("~p~n", [{error_in_crash_handler, Type2, Error2, erlang:get_stacktrace()}]),
         "Nitrogen.$console_log('crash_handler crashed in websocket');"
     end.
 


### PR DESCRIPTION
This addresses the issue raised in https://github.com/nitrogen/nitrogen_core/issues/136. With props to @bunnylushington as I worked from your proposed solution.

See Slack discussion here: https://erlanger.slack.com/archives/CFV94TLCA/p1629216894001400

I have my doubts about two specifics:
* I'm undecided about continuing to define `LOG` when the OTP logger has not been included -- since the parameters differ, it might introduce a more confusing incompatibility than removing it entirely, and encouraging any consumers to move to `WF_LOG` explicitly.
* I also somewhat dislike the check for whether the OTP logger is defined, which introduces a requirement that the OTP logger must be included **before** the Nitrogen library. I'm not sure if there's precedent for forcing a particular order of library inclusion.

I'm wondering if it might be better to avoid the `ifndef` entirely and force usage of the new logger -- would it make sense to import `logger.hrl` as a dependency of Nitrogen? (This may be a naive question, as I'm new to Nitrogen and to the Erlang ecosystem.)

n.b. This PR does not update `wf:info`, `wf:error` etc to use the new macro.

@choptastic please let me know what you think, and what further work might be needed. Thanks!