### PR TITLE
Handle unhandled websocket `EXIT` logs

### DIFF
--- a/src/nitrogen.erl
+++ b/src/nitrogen.erl
@@ -93,6 +93,8 @@ ws_info({comet_actions, Actions} , _Bridge, _State) ->
     wf:wire(page, page, Actions),
     Return = wf_core:run_websocket_comet(),
     {reply, {text, [<<"nitrogen_system_event:">>, Return]}};
+ws_info({'EXIT', _Pid, normal}, _Bridge, _State) ->
+    noreply;
 ws_info(Msg, _Bridge, _State) ->
     error_logger:warning_msg("Unhandled message(~p) to websocket process (~p)~n", [Msg, self()]),
     noreply.


### PR DESCRIPTION
As we built out our Nitrogen pages, we were seeing a lot of these in the logs:

```
{"level":"WARNING","log_type":"unrecognized_log","msg":" pid=<0.1062.0> unstructured_log=\"Unhandled message({'EXIT',<0.1066.0>,normal}) to websocket process (<0.1062.0>)\\\n\" ","service_name":"(redacted)","timestamp":"2021-08-24 17:53:19,867"}
```

They can be reproduced by spawning a function, e.g. by putting this anywhere in the page:

`erlang:spawn_link(fun() -> erlang:display(<<"test">>) end)`

When the spawned and linked function finishes, it sends an expected "normal exit" message to the linked process.

Our temporary workaround for this was to wrap any calls in a spurious `wf:comet`; the comet process seems to handle the normal exit messages properly.

This PR handles the normal exit messages in `ws_info` without generating a log message.

Let me know if there's a more correct way to handle this case, whether in Nitrogen or in our application.