### PR TITLE
Add isheader-attribute to tablecell-element

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -598,7 +598,8 @@
         align="left"            :: text() | atom(),
         valign="middle"         :: text() | atom(),
         colspan=1               :: integer(),
-        rowspan=1               :: integer()
+        rowspan=1               :: integer(),
+        isheader=false          :: true|false
     }).
 -record(singlerow, {?ELEMENT_BASE(element_singlerow),
         cells                   :: body()

--- a/src/elements/table/element_tablecell.erl
+++ b/src/elements/table/element_tablecell.erl
@@ -19,8 +19,8 @@ render_element(Record) ->
         wf:html_encode(Record#tablecell.text, Record#tablecell.html_encode),
         Record#tablecell.body
     ],
-
-    wf_tags:emit_tag(td, Body, [
+    Type = case Record#tablecell.isheader of true -> th; false -> td end,
+    wf_tags:emit_tag(Type, Body, [
         {id, Record#tablecell.html_id},
         {class, [tablecell, Record#tablecell.class]},
         {title, Record#tablecell.title},


### PR DESCRIPTION
In order to generate html-tables sometimes we want
to follow the thead/tr/th structure.

In the current version of nitrogen one cannot choose
between th- or td-elements. This patchs tries to fix this.

Alternatives tried: copy the tablecell into a tablehcell-module.
The difference being that tablehcell would be used for headers.

The code felt messy and since these changes are so minor this
became the first attempt.

Link:
 - https://www.w3schools.com/tags/tag_thead.asp