### PR TITLE
Add nitrogen:handler/3

### DIFF
--- a/doc/markdown/handlers.md
+++ b/doc/markdown/handlers.md
@@ -9,7 +9,7 @@ Core Nitrogen behavior has been broken out into well-defined, pluggable
 behavior modules called /handlers/. Handlers allow you to easily substitute
 your own logic for things like session, security, routing, and others. Simply
 create a module that implements one of the existing behaviors, and register it
-to call `nitrogen:handler/2` between the `nitrogen:init_request/2` and
+to call `nitrogen:handler/2` or `nitrogen:handler/3` between the `nitrogen:init_request/2` and
 `nitrogen:run/0` calls found inside the `nitrogen_xxx` (where `xxx` is the
 webserver used, for example 'mochiweb', 'yaws', 'cowboy', etc).
 
@@ -33,17 +33,28 @@ loading, but that's because the `nitrogen:handler/2` function determines,
 based on the `behavior()` defined within the handler module, which handler it
 is we're actually loading.
 
-## nitrogen:handler(HandlerName, Config)
+## nitrogen:handler(HandlerModule, Config)
 
 `nitrogen:handler/2` is the way to function to connect your custom handler into
 Nitrogen's handler system. This function takes two arguments:
 
- *  `HandlerName` - The name of the module.
+ *  `HandlerModule` - The name of the module.
 
  *  `Config` - Any configuration settings for this handler. This variable
       could be just about anything, a proplist containing API keys or IP
       addresses of related servers (say for a session handler connected to
       an external memcache or something.
+
+## nitrogen:handler(HandlerName, HandlerModule, Config)
+
+There is also the function `nitrogen:handler/3` which is useful if your modules
+are stripped and the function `nitrogen:handler/2` is not able to discovery the
+handler based on the `behaviour()` attribute. For such cases the
+`nitrogen:handler/3` works receiving an additional parameter:
+
+ * `HandlerName` - The type of handler.
+
+The rest of the parameters follows the `nitrogen:handler/2` definition.
 
 ## Common Handler Behavior Arguments
 

--- a/src/lib/wf_handler.erl
+++ b/src/lib/wf_handler.erl
@@ -8,7 +8,8 @@
     call/3,
     call_readonly/2, 
     call_readonly/3,
-    set_handler/2
+    set_handler/2,
+    set_handler/3
 ]).
 
 -spec init(#handler_context{}) -> ok.

--- a/src/nitrogen.erl
+++ b/src/nitrogen.erl
@@ -10,6 +10,7 @@
         init_request/2,
         init_request/1,
         handler/2,
+        handler/3,
         run/0
     ]).
 
@@ -43,6 +44,9 @@ init_request(Bridge) ->
 handler(Module, Config) ->
     wf_handler:set_handler(Module, Config).
 
+handler(Name, Module, Config) ->
+    wf_handler:set_handler(Name, Module, Config).
+
 run(Bridge) ->
     init_request(Bridge),
     nitrogen_main_handler:run().
@@ -69,10 +73,10 @@ ws_message_catched({nitrogen_postback,Msg}) ->
     Return = wf_core:run_websocket(Msg),
     [<<"nitrogen_event:">>,Return];
 ws_message_catched(flush_switchover_comet_actions) ->
-    %% If there are any actions that weren't 
+    %% If there are any actions that weren't
     ReconnectionRecovery = <<"Nitrogen.$reconnect_system();">>,
     case action_comet:get_actions_and_register_new_websocket_pid(self()) of
-        [] -> 
+        [] ->
             [<<"nitrogen_system_event:">>, ReconnectionRecovery];
         Actions ->
             wf:wire(page, page, Actions),
@@ -104,6 +108,6 @@ ws_terminate(_Reason, _Bridge, _State) ->
 
 
 %% Deprecated, kept for backwards compatibility. Use nitrogen:run/1 with simple_bridge
-run() -> 
+run() ->
     wf_core:run().
 


### PR DESCRIPTION
There are cases where the beam modules are stripped and is not possible
to get the attribute lists calling Module:module_info(attributes).

So the caller should pass the Name handler as the first parameter.
Avoiding calling the module_info/1 that might return an empty list.

The full picture is like that:

https://github.com/nitrogen/nitrogen_core/blob/master/src/nitrogen.erl#L44

https://github.com/nitrogen/nitrogen_core/blob/master/src/lib/wf_handler.erl#L67

The https://www.erlang.org/doc/reference_manual/modules.html says:

```
attributes

    Returns a list of {AttributeName,ValueList} tuples, where AttributeName is the name of an attribute, and ValueList is a list of values. Notice that a given attribute can occur more than once in the list with different values if the attribute occurs more than once in the module.

    The list of attributes becomes empty if the module is stripped with the beam_lib(3) module (in STDLIB).
```

Running the above code:

```
Module = debug_crash_handler, {module, Module} = code:ensure_loaded(Module), L = Module:module_info(attributes).
```

L will be [] if the debug_crash_handler is stripped.


As we use rebar3 to handle a relase with prod profile, the rebar3 default configuration is to strip all modules. An option
is configure the prod profile like following to avoid stripping modules:

```
{profiles, [
    %% prod: includes ERTS and system_libs.
    {prod, [
        {relx, [
            {include_erts, true},
            {system_libs, true},

            {debug_info, keep}

        ]}
    ]},
```
