### PR TITLE
Add code and pre with body element

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -266,6 +266,7 @@
         for=""                  :: id()
     }).
 -record(pre, {?ELEMENT_BASE(element_pre),
+        body=""                 :: body(),
         text=""                 :: text(),
         html_encode=true        :: html_encode()
      }).

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -339,6 +339,11 @@
         text=""                 :: text(),
         html_encode=true        :: html_encode()
     }).
+-record(code, {?ELEMENT_BASE(element_code),
+        body=""                 :: body(),
+        text=""                 :: text(),
+        html_encode=true        :: html_encode()
+     }).
 -record(textbox, {?ELEMENT_BASE(element_textbox),
         text=""                 :: text(),
         maxlength=""            :: integer() | string(),

--- a/src/elements/html/element_code.erl
+++ b/src/elements/html/element_code.erl
@@ -1,0 +1,26 @@
+% vim: sw=4 ts=4 et ft=erlang
+% Nitrogen Web Framework for Erlang
+% See MIT-LICENSE for licensing information.
+
+-module (element_code).
+-include("wf.hrl").
+-export([
+    reflect/0,
+    render_element/1
+]).
+
+-spec reflect() -> [atom()].
+reflect() -> record_info(fields, code).
+
+-spec render_element(#code{}) -> body().
+render_element(Record) ->
+    Body = [
+        wf:html_encode(Record#code.text, Record#code.html_encode),
+        Record#code.body
+    ],
+    wf_tags:emit_tag(code, Body, [
+        {class, [code, Record#code.class]},
+        {title, Record#code.title},
+        {data_fields, Record#code.data_fields},
+        {style, Record#code.style}
+    ]).

--- a/src/elements/html/element_pre.erl
+++ b/src/elements/html/element_pre.erl
@@ -15,7 +15,10 @@ reflect() -> record_info(fields, pre).
 
 -spec render_element(#pre{}) -> body().
 render_element(Record) ->
-    Body = wf:html_encode(Record#pre.text, Record#pre.html_encode),
+    Body = [
+        wf:html_encode(Record#pre.text, Record#pre.html_encode),
+        Record#pre.body
+    ],
     wf_tags:emit_tag(pre, Body, [
         {class, [pre, Record#pre.class]},
         {title, Record#pre.title},


### PR DESCRIPTION
Hello,

This adds html `code` element and for the html `pre` it is now possible to add body to it.

Let me know if both changes make sense. Or just one of them.

Thanks