### PR TITLE
Use Unicode-aware to-binary conversion when input might require it.

### DIFF
--- a/src/elements/forms/element_dropdown.erl
+++ b/src/elements/forms/element_dropdown.erl
@@ -70,7 +70,7 @@ format_options(#dropdown{options=Opts, value=Value0, html_encode=HtmlEncode}) ->
 binary_or_undefined(undefined) ->
     undefined;
 binary_or_undefined(V) ->
-    wf:to_binary(V).
+    wf:to_unicode_binary(V).
 
 
 create_option(Option) ->
@@ -135,7 +135,7 @@ is_selected(DropDownValue, #option{value=OptValue}) ->
     %% Finally, if none of the above short-circuits trip, then we can convert
     %% #option.value to binary and compare directly. If they match, then it's
     %% selected.
-    wf:to_binary(OptValue) =:= DropDownValue.
+    wf:to_unicode_binary(OptValue) =:= DropDownValue.
 
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/elements/html/element_image.erl
+++ b/src/elements/html/element_image.erl
@@ -24,7 +24,7 @@ render_element(Record) ->
         {height, Record#image.height},
         {width, Record#image.width},
         {alt, Record#image.alt},
-        {src, wf:to_binary(Record#image.image)}
+        {src, wf:to_unicode_binary(Record#image.image)}
     ],
 
     wf_tags:emit_tag(img, Attributes).

--- a/src/elements/layout/element_template.erl
+++ b/src/elements/layout/element_template.erl
@@ -28,7 +28,7 @@ render_element(Record) ->
                    File = wf:to_binary(Record#template.file),
                    get_cached_template(File, Record);
                  Text ->
-                   parse_template({content, wf:to_binary(Text)},
+                   parse_template({content, wf:to_unicode_binary(Text)},
                                   Record#template.from_type,
                                   Record#template.to_type,
                                   Record#template.callouts,

--- a/src/lib/wf_tags.erl
+++ b/src/lib/wf_tags.erl
@@ -141,10 +141,10 @@ data_tags(Data) ->
     [display_property(data_tag(Datum)) || Datum <- Data].
 
 data_tag({FieldName,Value}) ->
-    DataField = wf:to_binary(FieldName),
+    DataField = wf:to_unicode_binary(FieldName),
     {<<"data-",DataField/binary>>,Value};
 data_tag({FieldName}) ->
-    DataField = wf:to_binary(FieldName),
+    DataField = wf:to_unicode_binary(FieldName),
     {<<"data-",DataField/binary>>};
 data_tag(FieldName) when is_atom(FieldName) ->
     data_tag({FieldName}).


### PR DESCRIPTION
## Summary

Uses Unicode-aware binary conversion to avoid crashes with multi-byte characters.

I have not yet tested these changes or investigated how to test them, but I am happy to do so if the PR is deemed worthwhile and the approach sound.

## Description

In certain situations we've been passing an input to `wf:to_binary()` that may contain text with code points that form multi-byte sequences when encoded.

For example, the string `[127344, 127345, 127346]` corresponds to the string input "🅰🅱🅲", but corresponds to the UTF-8 byte sequence `[240,159,133,176,240,159,133,177,240,159,133,178]`.

Problematically, while we can easily convert from binary to a list in Erlang with `binary_to_list/1`, we cannot so easily convert from list to binary with `list_to_binary/1`, because that function operates on the `iolist()` datatype, which operates on bytes, not on abstract numbers.

Per the documentation for `iolist()` [1],

> In most use cases you want to use iodata() instead of this type.

Per the documentation for `iodata()` [2],

> To transcode a string() or unicode:chardata() to iodata()
> you can use unicode:characters_to_binary/1.

And the reason is that `unicode:characters_to_binary/1` will properly convert the code points in a string-list into the proper UTF-8 byte sequence that's necessary for the final output.

In this patch we're calling `wf:to_unicode_binary/1` in places where I found us to be passing likely-Unicode data. There might be more places that I didn't find, and one might argue that in some of the cases I changed, we don't expect Unicode data. The risk of the former is that this patch isn't a full fix for every case, but that doesn't imply these fixes are invalid; the risk of the latter is that we could choke on non-Unicode data, but that should only be the case _if_ the unpatched code would have also failed.

Noted in the erlang forums [3]

[1]: https://www.erlang.org/doc/man/erlang.html#type-iolist
[2]: https://www.erlang.org/doc/man/erlang.html#type-iodata
[3]: https://erlangforums.com/t/problem-with-non-latin-symbols-in-nitrogen-element-names/2087