### PR TITLE
Cookie same site

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -1157,7 +1157,7 @@
         minutes_to_live=20      :: integer(),
         secure=false            :: boolean(),
         http_only=false         :: boolean(),
-        same_site               = "Lax" ::text()
+        same_site               = lax ::atom()
     }).
 
 %%% Validators %%%

--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -1156,7 +1156,8 @@
         domain=undefined        :: undefined | text(),
         minutes_to_live=20      :: integer(),
         secure=false            :: boolean(),
-        http_only=false         :: boolean()
+        http_only=false         :: boolean(),
+        same_site               = "Lax" ::text()
     }).
 
 %%% Validators %%%

--- a/src/lib/wf_cookies.erl
+++ b/src/lib/wf_cookies.erl
@@ -51,7 +51,8 @@ set_websocket_cookie(Cookie, Value, Options) ->
         domain=proplists:get_value(path, Options, undefined),
         minutes_to_live=proplists:get_value(minutes_to_live, Options, 20),
         secure=proplists:get_value(secure, Options, false),
-        http_only=proplists:get_value(http_only, Options, false)
+        http_only=proplists:get_value(http_only, Options, false),
+        same_site=proplists:get_value(same_site, Options,"Lax")
     },
     wf:wire(SetCookie).
 

--- a/src/lib/wf_cookies.erl
+++ b/src/lib/wf_cookies.erl
@@ -52,7 +52,7 @@ set_websocket_cookie(Cookie, Value, Options) ->
         minutes_to_live=proplists:get_value(minutes_to_live, Options, 20),
         secure=proplists:get_value(secure, Options, false),
         http_only=proplists:get_value(http_only, Options, false),
-        same_site=proplists:get_value(same_site, Options,"Lax")
+        same_site=proplists:get_value(same_site, Options, lax)
     },
     wf:wire(SetCookie).
 


### PR DESCRIPTION
Add same-site cookie support.
NOTE:  should be used with latest version of simple_bridge.
Tested with cowboy