### PR TITLE
Honor the element label and value class instead nitrogen one

### DIFF
--- a/src/elements/forms/element_label.erl
+++ b/src/elements/forms/element_label.erl
@@ -21,9 +21,14 @@ render_element(Record) ->
     ],
     wf_tags:emit_tag(label, Body, [
         {id, Record#label.html_id},
-        {class, [nitrogen_label, Record#label.class]},
+        {class, [default_class(Record#label.class)]},
         {title, Record#label.title},
         {style, Record#label.style},
         {for, Record#label.for},
         {data_fields, Record#label.data_fields}
     ]).
+
+default_class([]) ->
+    nitrogen_label;
+default_class(Class) ->
+    Class.

--- a/src/elements/html/element_value.erl
+++ b/src/elements/html/element_value.erl
@@ -18,8 +18,13 @@ render_element(Record) ->
     Text = wf:html_encode(Record#value.text, Record#value.html_encode),
     wf_tags:emit_tag(span, Text, [
         {id, Record#value.html_id},
-        {class, [value, Record#value.class]},
+        {class, [default_class(Record#value.class)]},
         {title, Record#value.title},
         {style, Record#value.style},
         {data_fields, Record#value.data_fields}
     ]).
+
+default_class([]) ->
+    value;
+default_class(Class) ->
+    Class.

--- a/www/nitrogen.css
+++ b/www/nitrogen.css
@@ -4,7 +4,7 @@
 
 /***** Nitrogen Elements *****/
 
-label.nitrogen_label {
+.nitrogen_label {
     display: block;
     font-weight: bold;
 }


### PR DESCRIPTION
Hello,

When the element has a CSS class, nitrogen should honor that and avoid adding any other internal class. Now, if there is no element class then label and value elements add a default nitrogen classes (mostly for backward compatibility).

I'm not sure if this commit would break something. I believe it will not.