### PR TITLE
Register `beforeunload` event handler without jQuery

### DIFF
--- a/priv/www/nitrogen.js
+++ b/priv/www/nitrogen.js
@@ -1746,7 +1746,7 @@ var page = document;
 var Nitrogen = new NitrogenClass();
 
 
-$(window).on("beforeunload", function() {
+window.addEventListener('beforeunload', function() {
     // Give a "redirect prompt" if presented to prevent such.
     if(!Nitrogen.$allow_redirect) {
         return Nitrogen.$redirect_prompt;


### PR DESCRIPTION
Haven't tested it yet, however should work fine.