### PR TITLE
Add missing records: iframe and toggle_mobile_panel

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -838,6 +838,18 @@
         line_length=1           :: integer(),
         blank_length=0          :: integer()
     }).
+-record(iframe, {?ELEMENT_BASE(element_iframe),
+        align                   :: text() | atom(),
+        frameborder             :: integer() | undefined,
+        height                  :: integer() | undefined,
+        name=""                 :: text(),
+        sandbox=""              :: text(),
+        seamless                :: atom() | text(),
+        src                     :: url(),
+        srcdoc=""               :: text(),
+        width                   :: integer() | undefined,
+        allowfullscreen=true    :: boolean()
+    }).
 -record(google_chart,   {?ELEMENT_BASE(element_google_chart),
         type=line               :: google_chart_type(),
         color = <<"909090">>    :: color(),
@@ -1070,6 +1082,7 @@
         options=[]              :: proplist(),
         speed=500               :: integer()
     }).
+-record(toggle_mobile_panel, {?ACTION_BASE(action_toggle_mobile_panel)}).
 -record(add_class, {?ACTION_BASE(action_add_class),
         class=none              :: class(),
         speed=0                 :: integer()


### PR DESCRIPTION
I added the iframe and toggle_mobile_panel records again, for compatibility purposes with applications made using nitro_core 2.0.
I would like to know if these recordings were removed intentionally or if they were removed by mistake