### PR TITLE
Update: Prep for OTP/27

### DIFF
--- a/include/wf.hrl
+++ b/include/wf.hrl
@@ -1199,7 +1199,7 @@
 -record(if_value, {?ACTION_BASE(action_if_value),
         value                   :: atom() | text(),
         map                     :: undefined | [{atom() | text(), actions()}],
-        else=[]                 :: actions()
+        'else'=[]                 :: actions()
     }).
 
 -endif.

--- a/src/actions/action_if_value.erl
+++ b/src/actions/action_if_value.erl
@@ -9,7 +9,7 @@
 	render_action/1
 ]).
 
-render_action(#if_value{target=Target, map=Map, value=undefined, else=Else}) ->
+render_action(#if_value{target=Target, map=Map, value=undefined, 'else'=Else}) ->
     [
         wf:f(<<"switch(objs('~s').val()) {">>, [Target]),
             lists:map(fun({Value0, Actions}) ->
@@ -23,7 +23,7 @@ render_action(#if_value{target=Target, map=Map, value=undefined, else=Else}) ->
         <<"}">>
     ];
 
-render_action(#if_value{target=Target, map=undefined, value=Value0, actions=Actions, else=Else}) ->
+render_action(#if_value{target=Target, map=undefined, value=Value0, actions=Actions, 'else'=Else}) ->
     Value = wf:js_escape(wf:to_list(Value0)),
     [
         wf:f(<<"if(objs('~s').val()=='~s') {">>, [Target, Value]),


### PR DESCRIPTION
 - Avoid conflating `else` atom with new syntax.

---

@choptastic it's been a while. I recently updated to OTP/27 and this failed to build. Seems like all that really mattered was the use of `else` since maybe expressions are now enabled by default. I wrapped it in single quotes to make it an explicit atom.

This may not be what you have in mind. If that's the case, I'm happy to rearrange this patch as you see fit. I understand if you're too busy, but thanks regardless!